### PR TITLE
Add `TelegramUsername` to a Student's contact details

### DIFF
--- a/src/main/java/tuteez/logic/Messages.java
+++ b/src/main/java/tuteez/logic/Messages.java
@@ -45,6 +45,8 @@ public class Messages {
                 .append(person.getEmail())
                 .append("; Address: ")
                 .append(person.getAddress())
+                .append("; Telegram: ")
+                .append(person.getTelegramUsername())
                 .append("; Tags: ");
         person.getTags().forEach(builder::append);
         return builder.toString();

--- a/src/main/java/tuteez/logic/commands/AddCommand.java
+++ b/src/main/java/tuteez/logic/commands/AddCommand.java
@@ -6,6 +6,7 @@ import static tuteez.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static tuteez.logic.parser.CliSyntax.PREFIX_NAME;
 import static tuteez.logic.parser.CliSyntax.PREFIX_PHONE;
 import static tuteez.logic.parser.CliSyntax.PREFIX_TAG;
+import static tuteez.logic.parser.CliSyntax.PREFIX_TELEGRAM;
 
 import tuteez.commons.util.ToStringBuilder;
 import tuteez.logic.Messages;
@@ -26,12 +27,14 @@ public class AddCommand extends Command {
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
+            + PREFIX_TELEGRAM + "TELEGRAM USERNAME"
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
+            + PREFIX_TELEGRAM + "johndoe123 "
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney";
 

--- a/src/main/java/tuteez/logic/commands/AddCommand.java
+++ b/src/main/java/tuteez/logic/commands/AddCommand.java
@@ -37,7 +37,7 @@ public class AddCommand extends Command {
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
             + PREFIX_TELEGRAM + "johndoe123 "
             + PREFIX_TAG + "friends "
-            + PREFIX_TAG + "owesMoney"
+            + PREFIX_TAG + "owesMoney "
             + PREFIX_TAG + "Physics "
             + PREFIX_TAG + "Secondary 4 "
             + PREFIX_LESSON + "monday 0900-1100 "

--- a/src/main/java/tuteez/logic/commands/EditCommand.java
+++ b/src/main/java/tuteez/logic/commands/EditCommand.java
@@ -163,7 +163,8 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, address, tags);
+            return CollectionUtil.isAnyNonNull(name, phone, email, address,
+                    telegramUsername, tags);
         }
 
         public void setName(Name name) {

--- a/src/main/java/tuteez/logic/commands/EditCommand.java
+++ b/src/main/java/tuteez/logic/commands/EditCommand.java
@@ -1,11 +1,11 @@
 package tuteez.logic.commands;
 
-import static java.util.Objects.requireNonNull;
 import static tuteez.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static tuteez.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static tuteez.logic.parser.CliSyntax.PREFIX_NAME;
 import static tuteez.logic.parser.CliSyntax.PREFIX_PHONE;
 import static tuteez.logic.parser.CliSyntax.PREFIX_TAG;
+import static tuteez.logic.parser.CliSyntax.PREFIX_TELEGRAM;
 import static tuteez.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
@@ -26,6 +26,7 @@ import tuteez.model.person.Email;
 import tuteez.model.person.Name;
 import tuteez.model.person.Person;
 import tuteez.model.person.Phone;
+import tuteez.model.person.TelegramUsername;
 import tuteez.model.tag.Tag;
 
 /**
@@ -43,6 +44,7 @@ public class EditCommand extends Command {
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
+            + "[" + PREFIX_TELEGRAM + "TELEGRAM USERNAME] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
@@ -60,8 +62,8 @@ public class EditCommand extends Command {
      * @param editPersonDescriptor details to edit the person with
      */
     public EditCommand(Index index, EditPersonDescriptor editPersonDescriptor) {
-        requireNonNull(index);
-        requireNonNull(editPersonDescriptor);
+        Objects.requireNonNull(index);
+        Objects.requireNonNull(editPersonDescriptor);
 
         this.index = index;
         this.editPersonDescriptor = new EditPersonDescriptor(editPersonDescriptor);
@@ -69,7 +71,7 @@ public class EditCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        requireNonNull(model);
+        Objects.requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
@@ -99,9 +101,11 @@ public class EditCommand extends Command {
         Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
+        TelegramUsername updatedTelegramUser = editPersonDescriptor.getTelegramUsername()
+                .orElse(personToEdit.getTelegramUsername());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags);
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTelegramUser, updatedTags);
     }
 
     @Override
@@ -138,6 +142,7 @@ public class EditCommand extends Command {
         private Email email;
         private Address address;
         private Set<Tag> tags;
+        private TelegramUsername telegramUsername;
 
         public EditPersonDescriptor() {}
 
@@ -151,6 +156,7 @@ public class EditCommand extends Command {
             setEmail(toCopy.email);
             setAddress(toCopy.address);
             setTags(toCopy.tags);
+            setTelegramUsername(toCopy.telegramUsername);
         }
 
         /**
@@ -192,6 +198,14 @@ public class EditCommand extends Command {
             return Optional.ofNullable(address);
         }
 
+        public void setTelegramUsername(TelegramUsername username) {
+            this.telegramUsername = username;
+        }
+
+        public Optional<TelegramUsername> getTelegramUsername() {
+            return Optional.ofNullable(telegramUsername);
+        }
+
         /**
          * Sets {@code tags} to this object's {@code tags}.
          * A defensive copy of {@code tags} is used internally.
@@ -225,7 +239,8 @@ public class EditCommand extends Command {
                     && Objects.equals(phone, otherEditPersonDescriptor.phone)
                     && Objects.equals(email, otherEditPersonDescriptor.email)
                     && Objects.equals(address, otherEditPersonDescriptor.address)
-                    && Objects.equals(tags, otherEditPersonDescriptor.tags);
+                    && Objects.equals(tags, otherEditPersonDescriptor.tags)
+                    && Objects.equals(telegramUsername, otherEditPersonDescriptor.telegramUsername);
         }
 
         @Override
@@ -235,6 +250,7 @@ public class EditCommand extends Command {
                     .add("phone", phone)
                     .add("email", email)
                     .add("address", address)
+                    .add("telegramUsername", telegramUsername)
                     .add("tags", tags)
                     .toString();
         }

--- a/src/main/java/tuteez/logic/commands/EditCommand.java
+++ b/src/main/java/tuteez/logic/commands/EditCommand.java
@@ -27,11 +27,8 @@ import tuteez.model.person.Email;
 import tuteez.model.person.Name;
 import tuteez.model.person.Person;
 import tuteez.model.person.Phone;
-<<<<<<< HEAD
 import tuteez.model.person.TelegramUsername;
-=======
 import tuteez.model.person.lesson.Lesson;
->>>>>>> upstream/master
 import tuteez.model.tag.Tag;
 
 /**
@@ -112,11 +109,9 @@ public class EditCommand extends Command {
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
         Set<Lesson> updatedLessons = editPersonDescriptor.getLessons().orElse(personToEdit.getLessons());
 
-<<<<<<< HEAD
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTelegramUser, updatedTags);
-=======
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, updatedLessons);
->>>>>>> upstream/master
+
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTelegramUser, updatedTags,
+                updatedLessons);
     }
 
     @Override
@@ -153,11 +148,9 @@ public class EditCommand extends Command {
         private Email email;
         private Address address;
         private Set<Tag> tags;
-<<<<<<< HEAD
         private TelegramUsername telegramUsername;
-=======
         private Set<Lesson> lessons;
->>>>>>> upstream/master
+
 
         public EditPersonDescriptor() {}
 

--- a/src/main/java/tuteez/logic/parser/AddCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/AddCommandParser.java
@@ -6,6 +6,7 @@ import static tuteez.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static tuteez.logic.parser.CliSyntax.PREFIX_NAME;
 import static tuteez.logic.parser.CliSyntax.PREFIX_PHONE;
 import static tuteez.logic.parser.CliSyntax.PREFIX_TAG;
+import static tuteez.logic.parser.CliSyntax.PREFIX_TELEGRAM;
 
 import java.util.Set;
 import java.util.stream.Stream;
@@ -17,6 +18,7 @@ import tuteez.model.person.Email;
 import tuteez.model.person.Name;
 import tuteez.model.person.Person;
 import tuteez.model.person.Phone;
+import tuteez.model.person.TelegramUsername;
 import tuteez.model.tag.Tag;
 
 /**
@@ -31,21 +33,27 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                        PREFIX_TELEGRAM, PREFIX_TAG);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                PREFIX_TELEGRAM);
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
+        TelegramUsername telegramUsername = ParserUtil.parseTelegramUsername(
+                argMultimap.getValue(PREFIX_TELEGRAM).orElse(null));
+
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Person person = new Person(name, phone, email, address, tagList);
+
+        Person person = new Person(name, phone, email, address, telegramUsername, tagList);
 
         return new AddCommand(person);
     }

--- a/src/main/java/tuteez/logic/parser/CliSyntax.java
+++ b/src/main/java/tuteez/logic/parser/CliSyntax.java
@@ -11,4 +11,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_TELEGRAM = new Prefix("tg/");
 }

--- a/src/main/java/tuteez/logic/parser/EditCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/EditCommandParser.java
@@ -7,6 +7,7 @@ import static tuteez.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static tuteez.logic.parser.CliSyntax.PREFIX_NAME;
 import static tuteez.logic.parser.CliSyntax.PREFIX_PHONE;
 import static tuteez.logic.parser.CliSyntax.PREFIX_TAG;
+import static tuteez.logic.parser.CliSyntax.PREFIX_TELEGRAM;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -32,7 +33,8 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                        PREFIX_TELEGRAM, PREFIX_TAG);
 
         Index index;
 
@@ -42,7 +44,8 @@ public class EditCommandParser implements Parser<EditCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                PREFIX_TELEGRAM);
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 
@@ -57,6 +60,10 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
             editPersonDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
+        }
+        if (argMultimap.getValue(PREFIX_TELEGRAM).isPresent()) {
+            editPersonDescriptor.setTelegramUsername(ParserUtil.parseTelegramUsername(
+                    argMultimap.getValue(PREFIX_TELEGRAM).get()));
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
 

--- a/src/main/java/tuteez/logic/parser/ParserUtil.java
+++ b/src/main/java/tuteez/logic/parser/ParserUtil.java
@@ -13,6 +13,7 @@ import tuteez.model.person.Address;
 import tuteez.model.person.Email;
 import tuteez.model.person.Name;
 import tuteez.model.person.Phone;
+import tuteez.model.person.TelegramUsername;
 import tuteez.model.tag.Tag;
 
 /**
@@ -120,5 +121,23 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    /**
+     * Parses the input {@code String username} into a {@code TelegramUsername}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @param username the input telegram username, which can be null to represent an optional username.
+     * @throws ParseException if the given {@code telegramUsername} is invalid.
+     */
+    public static TelegramUsername parseTelegramUsername(String username) throws ParseException {
+        if (username == null) {
+            return TelegramUsername.empty();
+        }
+        String trimmedUsername = username.trim();
+        if (!TelegramUsername.isValidTelegramHandle(trimmedUsername)) {
+            throw new ParseException(TelegramUsername.MESSAGE_CONSTRAINTS);
+        }
+        return TelegramUsername.of(trimmedUsername);
     }
 }

--- a/src/main/java/tuteez/logic/parser/ParserUtil.java
+++ b/src/main/java/tuteez/logic/parser/ParserUtil.java
@@ -142,7 +142,8 @@ public class ParserUtil {
         return TelegramUsername.of(trimmedUsername);
     }
 
-    /** Parses a {@code String lesson} into a {@code Lesson}.
+    /**
+     * Parses a {@code String lesson} into a {@code Lesson}.
      * Leading and trailing whitespaces will be trimmed.
      *
      * @throws ParseException if the given {@code tag} is invalid.

--- a/src/main/java/tuteez/model/person/Person.java
+++ b/src/main/java/tuteez/model/person/Person.java
@@ -20,6 +20,7 @@ public class Person {
     private final Name name;
     private final Phone phone;
     private final Email email;
+    private final TelegramUsername telegramUsername;
 
     // Data fields
     private final Address address;
@@ -28,13 +29,14 @@ public class Person {
     /**
      * Every field must be present and not null.
      */
-    public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags) {
+    public Person(Name name, Phone phone, Email email, Address address, TelegramUsername teleHandle, Set<Tag> tags) {
         requireAllNonNull(name, phone, email, address, tags);
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
         this.tags.addAll(tags);
+        this.telegramUsername = teleHandle;
     }
 
     public Name getName() {
@@ -59,6 +61,10 @@ public class Person {
      */
     public Set<Tag> getTags() {
         return Collections.unmodifiableSet(tags);
+    }
+
+    public TelegramUsername getTelegramUsername() {
+        return telegramUsername;
     }
 
     /**
@@ -94,13 +100,14 @@ public class Person {
                 && phone.equals(otherPerson.phone)
                 && email.equals(otherPerson.email)
                 && address.equals(otherPerson.address)
-                && tags.equals(otherPerson.tags);
+                && tags.equals(otherPerson.tags)
+                && telegramUsername.equals(otherPerson.telegramUsername);
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, tags);
+        return Objects.hash(name, phone, email, address, telegramUsername, tags);
     }
 
     @Override
@@ -110,6 +117,7 @@ public class Person {
                 .add("phone", phone)
                 .add("email", email)
                 .add("address", address)
+                .add("telegramUsername", telegramUsername)
                 .add("tags", tags)
                 .toString();
     }

--- a/src/main/java/tuteez/model/person/TelegramUsername.java
+++ b/src/main/java/tuteez/model/person/TelegramUsername.java
@@ -1,0 +1,70 @@
+package tuteez.model.person;
+
+import static java.util.Objects.requireNonNull;
+import static tuteez.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Person's telegram username in the address book.
+ * The person's telegram username is optional.
+ * Guarantees: immutable; is valid as declared in {@link #isValidTelegramHandle(String)}
+ */
+public class TelegramUsername {
+    public static final String MESSAGE_CONSTRAINTS =
+            "Telegram usernames must be at least 5 characters long, and can only contain a-z/A-Z, 0-9, and underscores."
+            + " Telegram usernames are case insensitive, and will be in lowercase. It must start with a letter,"
+            + " and should not be blank.";
+
+    public static final String VALIDATION_REGEX = "^[a-zA-Z][a-zA-Z0-9_]{4,31}$";
+
+    public final String telegramHandle;
+
+    /**
+     * Constructs a {@code TelegramUsername}.
+     * @param username A valid telegram handle.
+     */
+    public TelegramUsername(String username) {
+        requireNonNull(username);
+        checkArgument(isValidTelegramHandle(username), MESSAGE_CONSTRAINTS);
+        this.telegramHandle = username;
+    }
+
+    /**
+     * Returns true if a given string is a valid telegram handle.
+     * @param test the string to test
+     */
+    public static boolean isValidTelegramHandle(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    /**
+     * Returns the telegram handle in lowercase.
+     */
+    public String toLowerCaseUsername() {
+        return telegramHandle.toLowerCase();
+    }
+
+    @Override
+    public String toString() {
+        return toLowerCaseUsername();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof TelegramUsername)) {
+            return false;
+        }
+
+        TelegramUsername otherTeleHandle = (TelegramUsername) other;
+        return this.toLowerCaseUsername().equalsIgnoreCase(otherTeleHandle.toLowerCaseUsername());
+    }
+
+    @Override
+    public int hashCode() {
+        return toLowerCaseUsername().hashCode();
+    }
+
+}

--- a/src/main/java/tuteez/model/person/TelegramUsername.java
+++ b/src/main/java/tuteez/model/person/TelegramUsername.java
@@ -16,16 +16,35 @@ public class TelegramUsername {
 
     public static final String VALIDATION_REGEX = "^[a-zA-Z][a-zA-Z0-9_]{4,31}$";
 
-    public final String telegramHandle;
+    public final String telegramUsername;
 
     /**
      * Constructs a {@code TelegramUsername}.
+     * Private constructor to enforce the use of the static factory method.
      * @param username A valid telegram handle.
      */
-    public TelegramUsername(String username) {
+    private TelegramUsername(String username) {
+        this.telegramUsername = username;
+    }
+
+    /**
+     * Factory method to create a TelegramUsername object with a valid telegram handle.
+     * @param username A valid telegram handle.
+     * @return A TelegramUsername instance.
+     */
+    public static TelegramUsername of(String username) {
         requireNonNull(username);
         checkArgument(isValidTelegramHandle(username), MESSAGE_CONSTRAINTS);
-        this.telegramHandle = username;
+        return new TelegramUsername(username.toLowerCase());
+    }
+
+    /**
+     * Factory method to create a TelegramUsername object with an empty username.
+     * This is used to represent the optional nature of the telegram handle.
+     * @return A TelegramUsername instance with no username.
+     */
+    public static TelegramUsername empty() {
+        return new TelegramUsername(null);
     }
 
     /**
@@ -36,16 +55,12 @@ public class TelegramUsername {
         return test.matches(VALIDATION_REGEX);
     }
 
-    /**
-     * Returns the telegram handle in lowercase.
-     */
-    public String toLowerCaseUsername() {
-        return telegramHandle.toLowerCase();
-    }
-
     @Override
     public String toString() {
-        return toLowerCaseUsername();
+        if (telegramUsername == null) {
+            return "";
+        }
+        return telegramUsername;
     }
 
     @Override
@@ -59,12 +74,12 @@ public class TelegramUsername {
         }
 
         TelegramUsername otherTeleHandle = (TelegramUsername) other;
-        return this.toLowerCaseUsername().equalsIgnoreCase(otherTeleHandle.toLowerCaseUsername());
+        return this.telegramUsername.equals(otherTeleHandle.telegramUsername);
     }
 
     @Override
     public int hashCode() {
-        return toLowerCaseUsername().hashCode();
+        return telegramUsername == null ? 0 : telegramUsername.hashCode();
     }
 
 }

--- a/src/main/java/tuteez/model/person/TelegramUsername.java
+++ b/src/main/java/tuteez/model/person/TelegramUsername.java
@@ -3,6 +3,8 @@ package tuteez.model.person;
 import static java.util.Objects.requireNonNull;
 import static tuteez.commons.util.AppUtil.checkArgument;
 
+import java.util.Objects;
+
 /**
  * Represents a Person's telegram username in the address book.
  * The person's telegram username is optional.
@@ -74,6 +76,9 @@ public class TelegramUsername {
         }
 
         TelegramUsername otherTeleHandle = (TelegramUsername) other;
+        if (telegramUsername == null) {
+            return Objects.equals(otherTeleHandle.telegramUsername, null);
+        }
         return this.telegramUsername.equals(otherTeleHandle.telegramUsername);
     }
 

--- a/src/main/java/tuteez/model/util/SampleDataUtil.java
+++ b/src/main/java/tuteez/model/util/SampleDataUtil.java
@@ -11,6 +11,7 @@ import tuteez.model.person.Email;
 import tuteez.model.person.Name;
 import tuteez.model.person.Person;
 import tuteez.model.person.Phone;
+import tuteez.model.person.TelegramUsername;
 import tuteez.model.tag.Tag;
 
 /**
@@ -20,22 +21,22 @@ public class SampleDataUtil {
     public static Person[] getSamplePersons() {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
-                new Address("Blk 30 Geylang Street 29, #06-40"),
+                new Address("Blk 30 Geylang Street 29, #06-40"), TelegramUsername.of("alex_yeoh"),
                 getTagSet("friends")),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
-                new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
+                new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), TelegramUsername.of("bernice_yu"),
                 getTagSet("colleagues", "friends")),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
-                new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
+                new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), TelegramUsername.of("charlotte_oliveiro"),
                 getTagSet("neighbours")),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
-                new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
+                new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), TelegramUsername.of("david_li"),
                 getTagSet("family")),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
-                new Address("Blk 47 Tampines Street 20, #17-35"),
+                new Address("Blk 47 Tampines Street 20, #17-35"), TelegramUsername.of("irfan_ibrahim"),
                 getTagSet("classmates")),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
-                new Address("Blk 45 Aljunied Street 85, #11-31"),
+                new Address("Blk 45 Aljunied Street 85, #11-31"), TelegramUsername.of("roy_balakrishnan"),
                 getTagSet("colleagues"))
         };
     }

--- a/src/main/java/tuteez/model/util/SampleDataUtil.java
+++ b/src/main/java/tuteez/model/util/SampleDataUtil.java
@@ -11,11 +11,8 @@ import tuteez.model.person.Email;
 import tuteez.model.person.Name;
 import tuteez.model.person.Person;
 import tuteez.model.person.Phone;
-<<<<<<< HEAD
 import tuteez.model.person.TelegramUsername;
-=======
 import tuteez.model.person.lesson.Lesson;
->>>>>>> upstream/master
 import tuteez.model.tag.Tag;
 
 /**
@@ -25,43 +22,23 @@ public class SampleDataUtil {
     public static Person[] getSamplePersons() {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
-<<<<<<< HEAD
                 new Address("Blk 30 Geylang Street 29, #06-40"), TelegramUsername.of("alex_yeoh"),
-                getTagSet("friends")),
-            new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
-                new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), TelegramUsername.of("bernice_yu"),
-                getTagSet("colleagues", "friends")),
-            new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
-                new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), TelegramUsername.of("charlotte_oliveiro"),
-                getTagSet("neighbours")),
-            new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
-                new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), TelegramUsername.of("david_li"),
-                getTagSet("family")),
-            new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
-                new Address("Blk 47 Tampines Street 20, #17-35"), TelegramUsername.of("irfan_ibrahim"),
-                getTagSet("classmates")),
-            new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
-                new Address("Blk 45 Aljunied Street 85, #11-31"), TelegramUsername.of("roy_balakrishnan"),
-                getTagSet("colleagues"))
-=======
-                new Address("Blk 30 Geylang Street 29, #06-40"),
                 getTagSet("Chemistry"), getLessonSet("monday 0900-1000")),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
-                new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
+                new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), TelegramUsername.of("bernice_yu"),
                 getTagSet("Physics", "Sec 4"), getLessonSet("tuesday 1000-1100")),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
-                new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
+                new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), TelegramUsername.of("charlotte_oliveiro"),
                 getTagSet("Primary 6"), getLessonSet("wednesday 1000-1200")),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
-                new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
+                new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), TelegramUsername.of("david_li"),
                 getTagSet("JC math"), getLessonSet("friday 1000-1100")),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
-                new Address("Blk 47 Tampines Street 20, #17-35"),
+                new Address("Blk 47 Tampines Street 20, #17-35"), TelegramUsername.of("irfan_ibrahim"),
                 getTagSet("Uni math"), getLessonSet("saturday 0900-1100")),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
-                new Address("Blk 45 Aljunied Street 85, #11-31"),
+                new Address("Blk 45 Aljunied Street 85, #11-31"), TelegramUsername.of("roy_balakrishnan"),
                 getTagSet("secondary science"), getLessonSet("sunday 0900-1100"))
->>>>>>> upstream/master
         };
     }
 

--- a/src/main/java/tuteez/storage/JsonAdaptedPerson.java
+++ b/src/main/java/tuteez/storage/JsonAdaptedPerson.java
@@ -15,6 +15,7 @@ import tuteez.model.person.Email;
 import tuteez.model.person.Name;
 import tuteez.model.person.Person;
 import tuteez.model.person.Phone;
+import tuteez.model.person.TelegramUsername;
 import tuteez.model.tag.Tag;
 
 /**
@@ -28,6 +29,7 @@ class JsonAdaptedPerson {
     private final String phone;
     private final String email;
     private final String address;
+    private final String telegramUsername;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
 
     /**
@@ -36,11 +38,13 @@ class JsonAdaptedPerson {
     @JsonCreator
     public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
             @JsonProperty("email") String email, @JsonProperty("address") String address,
+            @JsonProperty("telegramUsername") String telegramUsername,
             @JsonProperty("tags") List<JsonAdaptedTag> tags) {
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
+        this.telegramUsername = telegramUsername;
         if (tags != null) {
             this.tags.addAll(tags);
         }
@@ -54,6 +58,7 @@ class JsonAdaptedPerson {
         phone = source.getPhone().value;
         email = source.getEmail().value;
         address = source.getAddress().value;
+        telegramUsername = source.getTelegramUsername().telegramUsername;
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
@@ -102,8 +107,21 @@ class JsonAdaptedPerson {
         }
         final Address modelAddress = new Address(address);
 
+        TelegramUsername modelTelegramUsername = getModelTelegramUsername(telegramUsername);
+
         final Set<Tag> modelTags = new HashSet<>(personTags);
-        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelTags);
+        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelTelegramUsername, modelTags);
+    }
+
+    private TelegramUsername getModelTelegramUsername(String username) throws IllegalValueException {
+        if (username == null) {
+            return TelegramUsername.empty();
+        } else {
+            if (!TelegramUsername.isValidTelegramHandle(username)) {
+                throw new IllegalValueException(TelegramUsername.MESSAGE_CONSTRAINTS);
+            }
+            return TelegramUsername.of(username);
+        }
     }
 
 }

--- a/src/main/java/tuteez/storage/JsonAdaptedPerson.java
+++ b/src/main/java/tuteez/storage/JsonAdaptedPerson.java
@@ -116,12 +116,11 @@ class JsonAdaptedPerson {
     private TelegramUsername getModelTelegramUsername(String username) throws IllegalValueException {
         if (username == null) {
             return TelegramUsername.empty();
-        } else {
-            if (!TelegramUsername.isValidTelegramHandle(username)) {
-                throw new IllegalValueException(TelegramUsername.MESSAGE_CONSTRAINTS);
-            }
-            return TelegramUsername.of(username);
         }
+        if (!TelegramUsername.isValidTelegramHandle(username)) {
+            throw new IllegalValueException(TelegramUsername.MESSAGE_CONSTRAINTS);
+        }
+        return TelegramUsername.of(username);
     }
 
 }

--- a/src/main/java/tuteez/storage/JsonAdaptedPerson.java
+++ b/src/main/java/tuteez/storage/JsonAdaptedPerson.java
@@ -15,11 +15,8 @@ import tuteez.model.person.Email;
 import tuteez.model.person.Name;
 import tuteez.model.person.Person;
 import tuteez.model.person.Phone;
-<<<<<<< HEAD
 import tuteez.model.person.TelegramUsername;
-=======
 import tuteez.model.person.lesson.Lesson;
->>>>>>> upstream/master
 import tuteez.model.tag.Tag;
 
 /**

--- a/src/main/java/tuteez/ui/PersonCard.java
+++ b/src/main/java/tuteez/ui/PersonCard.java
@@ -66,8 +66,7 @@ public class PersonCard extends UiPart<Region> {
         if (username != null && username.telegramUsername != null && !username.telegramUsername.isEmpty()) {
             telegram.setText("@" + username.telegramUsername);
             telegram.setVisible(true);
-        }
-        if (username.telegramUsername == null) {
+        } else {
             telegram.setVisible(false);
         }
     }

--- a/src/main/java/tuteez/ui/PersonCard.java
+++ b/src/main/java/tuteez/ui/PersonCard.java
@@ -8,6 +8,7 @@ import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import tuteez.model.person.Person;
+import tuteez.model.person.TelegramUsername;
 
 /**
  * An UI component that displays information of a {@code Person}.
@@ -35,6 +36,8 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label phone;
     @FXML
+    private Label telegram;
+    @FXML
     private Label address;
     @FXML
     private Label email;
@@ -50,10 +53,22 @@ public class PersonCard extends UiPart<Region> {
         id.setText(displayedIndex + ". ");
         name.setText(person.getName().fullName);
         phone.setText(person.getPhone().value);
+        setTelegramUsernameText(person);
         address.setText(person.getAddress().value);
         email.setText(person.getEmail().value);
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+    }
+
+    private void setTelegramUsernameText(Person person) {
+        TelegramUsername username = person.getTelegramUsername();
+        if (username != null && username.telegramUsername != null && !username.telegramUsername.isEmpty()) {
+            telegram.setText("@" + username.telegramUsername);
+            telegram.setVisible(true);
+        }
+        if (username.telegramUsername == null) {
+            telegram.setVisible(false);
+        }
     }
 }

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -29,6 +29,7 @@
       </HBox>
       <FlowPane fx:id="tags" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
+      <Label fx:id="telegram" styleClass="cell_small_label" text="\$telegram" managed="${telegram.visible}" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
     </VBox>

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -5,42 +5,49 @@
     "phone" : "94351253",
     "email" : "alice@example.com",
     "address" : "123, Jurong West Ave 6, #08-111",
+    "telegramUsername" : "alice_pauline",
     "tags" : [ "friends" ]
   }, {
     "name" : "Benson Meier",
     "phone" : "98765432",
     "email" : "johnd@example.com",
     "address" : "311, Clementi Ave 2, #02-25",
+    "telegramUsername" : "benson_meier",
     "tags" : [ "owesMoney", "friends" ]
   }, {
     "name" : "Carl Kurz",
     "phone" : "95352563",
     "email" : "heinz@example.com",
     "address" : "wall street",
+    "telegramUsername" : "carl_kurz",
     "tags" : [ ]
   }, {
     "name" : "Daniel Meier",
     "phone" : "87652533",
     "email" : "cornelia@example.com",
     "address" : "10th street",
+    "telegramUsername" : "daniel_meier",
     "tags" : [ "friends" ]
   }, {
     "name" : "Elle Meyer",
     "phone" : "9482224",
     "email" : "werner@example.com",
     "address" : "michegan ave",
+    "telegramUsername" : "elle_meyer",
     "tags" : [ ]
   }, {
     "name" : "Fiona Kunz",
     "phone" : "9482427",
     "email" : "lydia@example.com",
     "address" : "little tokyo",
+    "telegramUsername" : "fiona_kunz",
     "tags" : [ ]
   }, {
     "name" : "George Best",
     "phone" : "9482442",
     "email" : "anna@example.com",
     "address" : "4th street",
+    "telegramUsername" : "george_best",
     "tags" : [ ]
   } ]
 }

--- a/src/test/java/tuteez/logic/LogicManagerTest.java
+++ b/src/test/java/tuteez/logic/LogicManagerTest.java
@@ -7,6 +7,7 @@ import static tuteez.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static tuteez.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static tuteez.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static tuteez.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
+import static tuteez.logic.commands.CommandTestUtil.TELEGRAM_DESC_AMY;
 import static tuteez.testutil.Assert.assertThrows;
 import static tuteez.testutil.TypicalPersons.AMY;
 
@@ -166,8 +167,8 @@ public class LogicManagerTest {
 
         // Triggers the saveAddressBook method by executing an add command
         String addCommand = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY
-                + EMAIL_DESC_AMY + ADDRESS_DESC_AMY;
-        Person expectedPerson = new PersonBuilder(AMY).withTags().build();
+                + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + TELEGRAM_DESC_AMY;
+        Person expectedPerson = new PersonBuilder(AMY).withTelegram("amy_bee").withTags().build();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addPerson(expectedPerson);
         assertCommandFailure(addCommand, CommandException.class, expectedMessage, expectedModel);

--- a/src/test/java/tuteez/logic/commands/CommandTestUtil.java
+++ b/src/test/java/tuteez/logic/commands/CommandTestUtil.java
@@ -7,6 +7,7 @@ import static tuteez.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static tuteez.logic.parser.CliSyntax.PREFIX_NAME;
 import static tuteez.logic.parser.CliSyntax.PREFIX_PHONE;
 import static tuteez.logic.parser.CliSyntax.PREFIX_TAG;
+import static tuteez.logic.parser.CliSyntax.PREFIX_TELEGRAM;
 import static tuteez.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;
@@ -34,6 +35,8 @@ public class CommandTestUtil {
     public static final String VALID_EMAIL_BOB = "bob@example.com";
     public static final String VALID_ADDRESS_AMY = "Block 312, Amy Street 1";
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
+    public static final String VALID_TELEGRAM_AMY = "amy_bee";
+    public static final String VALID_TELEGRAM_BOB = "bob_choo";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
 
@@ -45,6 +48,8 @@ public class CommandTestUtil {
     public static final String EMAIL_DESC_BOB = " " + PREFIX_EMAIL + VALID_EMAIL_BOB;
     public static final String ADDRESS_DESC_AMY = " " + PREFIX_ADDRESS + VALID_ADDRESS_AMY;
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
+    public static final String TELEGRAM_DESC_AMY = " " + PREFIX_TELEGRAM + VALID_TELEGRAM_AMY;
+    public static final String TELEGRAM_DESC_BOB = " " + PREFIX_TELEGRAM + VALID_TELEGRAM_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
 
@@ -52,6 +57,7 @@ public class CommandTestUtil {
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
+    public static final String INVALID_TELEGRAM_DESC = " " + PREFIX_TELEGRAM + "amybee!"; // '!' not allowed in username
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
@@ -63,9 +69,11 @@ public class CommandTestUtil {
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
+                .withTelegram(VALID_TELEGRAM_AMY)
                 .withTags(VALID_TAG_FRIEND).build();
         DESC_BOB = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
+                .withTelegram(VALID_TELEGRAM_BOB)
                 .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
     }
 

--- a/src/test/java/tuteez/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/tuteez/logic/commands/EditPersonDescriptorTest.java
@@ -64,7 +64,8 @@ public class EditPersonDescriptorTest {
                 + editPersonDescriptor.getName().orElse(null) + ", phone="
                 + editPersonDescriptor.getPhone().orElse(null) + ", email="
                 + editPersonDescriptor.getEmail().orElse(null) + ", address="
-                + editPersonDescriptor.getAddress().orElse(null) + ", tags="
+                + editPersonDescriptor.getAddress().orElse(null) + ", telegramUsername="
+                + editPersonDescriptor.getTelegramUsername().orElse(null) + ", tags="
                 + editPersonDescriptor.getTags().orElse(null) + "}";
         assertEquals(expected, editPersonDescriptor.toString());
     }

--- a/src/test/java/tuteez/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/tuteez/logic/parser/AddCommandParserTest.java
@@ -18,12 +18,15 @@ import static tuteez.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static tuteez.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static tuteez.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static tuteez.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static tuteez.logic.commands.CommandTestUtil.TELEGRAM_DESC_AMY;
+import static tuteez.logic.commands.CommandTestUtil.TELEGRAM_DESC_BOB;
 import static tuteez.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static tuteez.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static tuteez.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static tuteez.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static tuteez.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static tuteez.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static tuteez.logic.commands.CommandTestUtil.VALID_TELEGRAM_BOB;
 import static tuteez.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static tuteez.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static tuteez.logic.parser.CliSyntax.PREFIX_NAME;
@@ -54,14 +57,15 @@ public class AddCommandParserTest {
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
+                + ADDRESS_DESC_BOB + TELEGRAM_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
 
 
         // multiple tags - all accepted
         Person expectedPersonMultipleTags = new PersonBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
                 .build();
         assertParseSuccess(parser,
-                NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + TELEGRAM_DESC_BOB
+                        + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 new AddCommand(expectedPersonMultipleTags));
     }
 
@@ -130,10 +134,20 @@ public class AddCommandParserTest {
     }
 
     @Test
-    public void parse_optionalFieldsMissing_success() {
+    public void parse_optionalFieldsTagsMissing_success() {
         // zero tags
-        Person expectedPerson = new PersonBuilder(AMY).withTags().build();
-        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY,
+        Person expectedPerson = new PersonBuilder(AMY).withTelegram("amy_bee").withTags().build();
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
+                + TELEGRAM_DESC_AMY,
+                new AddCommand(expectedPerson));
+    }
+
+    @Test
+    public void parse_optionalFieldsTelegramMissing_success() {
+        Person expectedPerson = new PersonBuilder(AMY).withTelegram(null)
+                .withTags(VALID_TAG_FRIEND).build();
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
+                + TAG_DESC_FRIEND,
                 new AddCommand(expectedPerson));
     }
 

--- a/src/test/java/tuteez/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/tuteez/logic/parser/AddCommandParserTest.java
@@ -26,7 +26,6 @@ import static tuteez.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static tuteez.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static tuteez.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static tuteez.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
-import static tuteez.logic.commands.CommandTestUtil.VALID_TELEGRAM_BOB;
 import static tuteez.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static tuteez.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static tuteez.logic.parser.CliSyntax.PREFIX_NAME;

--- a/src/test/java/tuteez/model/person/PersonTest.java
+++ b/src/test/java/tuteez/model/person/PersonTest.java
@@ -93,7 +93,8 @@ public class PersonTest {
     @Test
     public void toStringMethod() {
         String expected = Person.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
-                + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", tags=" + ALICE.getTags() + "}";
+                + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress()
+                + ", telegramUsername=" + ALICE.getTelegramUsername() + ", tags=" + ALICE.getTags() + "}";
         assertEquals(expected, ALICE.toString());
     }
 }

--- a/src/test/java/tuteez/model/person/PersonTest.java
+++ b/src/test/java/tuteez/model/person/PersonTest.java
@@ -8,6 +8,7 @@ import static tuteez.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static tuteez.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static tuteez.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static tuteez.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static tuteez.logic.commands.CommandTestUtil.VALID_TELEGRAM_BOB;
 import static tuteez.testutil.Assert.assertThrows;
 import static tuteez.testutil.TypicalPersons.ALICE;
 import static tuteez.testutil.TypicalPersons.BOB;
@@ -34,7 +35,8 @@ public class PersonTest {
 
         // same name, all other attributes different -> returns true
         Person editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
-                .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND).build();
+                .withAddress(VALID_ADDRESS_BOB).withTelegram(VALID_TELEGRAM_BOB)
+                .withTags(VALID_TAG_HUSBAND).build();
         assertTrue(ALICE.isSamePerson(editedAlice));
 
         // name differs in case, all other attributes same -> returns true
@@ -83,6 +85,10 @@ public class PersonTest {
 
         // different address -> returns false
         editedAlice = new PersonBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).build();
+        assertFalse(ALICE.equals(editedAlice));
+
+        // different telegram username -> returns false
+        editedAlice = new PersonBuilder(ALICE).withTelegram(VALID_TELEGRAM_BOB).build();
         assertFalse(ALICE.equals(editedAlice));
 
         // different tags -> returns false

--- a/src/test/java/tuteez/model/person/TelegramUsernameTest.java
+++ b/src/test/java/tuteez/model/person/TelegramUsernameTest.java
@@ -1,0 +1,97 @@
+package tuteez.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static tuteez.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class TelegramUsernameTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new TelegramUsername(null));
+    }
+
+    @Test
+    public void constructor_invalidUsername_throwsIllegalArgumentException() {
+        String invalidUsername = "john wick$";
+        assertThrows(IllegalArgumentException.class, () -> new TelegramUsername(invalidUsername));
+    }
+
+    @Test
+    public void isValidUsername() {
+        // null username
+        assertThrows(NullPointerException.class, () -> TelegramUsername.isValidTelegramHandle(null));
+
+        // invalid usernames
+        assertFalse(TelegramUsername.isValidTelegramHandle("")); // empty string
+        assertFalse(TelegramUsername.isValidTelegramHandle(" ")); // spaces only
+        assertFalse(TelegramUsername.isValidTelegramHandle("john wick")); // contains space
+        assertFalse(TelegramUsername.isValidTelegramHandle("john_wick$")); // contains special character
+        assertFalse(TelegramUsername.isValidTelegramHandle("johnwick#!@()")); // contains special characters
+        assertFalse(TelegramUsername.isValidTelegramHandle("john")); // less than 5 characters
+        assertFalse(TelegramUsername.isValidTelegramHandle("johnwick".repeat(5))); // more than 32 characters
+        assertFalse(TelegramUsername.isValidTelegramHandle("_johnwick")); // does not start with letter
+        assertFalse(TelegramUsername.isValidTelegramHandle("3johnwick")); // does not start with letter
+        assertFalse(TelegramUsername.isValidTelegramHandle("$$$$$$")); // contains special characters only
+
+        // valid usernames
+        assertTrue(TelegramUsername.isValidTelegramHandle("johnwick"));
+        assertTrue(TelegramUsername.isValidTelegramHandle("john_wick"));
+        assertTrue(TelegramUsername.isValidTelegramHandle("johnwick123"));
+        assertTrue(TelegramUsername.isValidTelegramHandle("johnwick_123"));
+        assertTrue(TelegramUsername.isValidTelegramHandle("a".repeat(5))); // exactly 5 characters
+        assertTrue(TelegramUsername.isValidTelegramHandle("a".repeat(32))); // exactly 32 characters
+        assertTrue(TelegramUsername.isValidTelegramHandle("CaptainAmerica")); // capitalisation allowed
+    }
+
+    @Test
+    public void equals() {
+        TelegramUsername user1 = new TelegramUsername("johnwick");
+        TelegramUsername user2 = new TelegramUsername("johnwick");
+        TelegramUsername user3 = new TelegramUsername("john_wick");
+        TelegramUsername user4 = new TelegramUsername("JohnWick");
+
+        // same object -> returns true
+        assertTrue(user1.equals(user1));
+
+        // same values -> returns true
+        assertTrue(user1.equals(user2));
+
+        // different capitalisation -> returns true
+        assertTrue(user1.equals(user4));
+
+        // null -> returns false
+        assertFalse(user1.equals(null));
+
+        // different values -> returns false
+        assertFalse(user1.equals(user3));
+
+        // different types (other is String) -> returns false
+        assertFalse(user1.equals("johnwick"));
+    }
+
+    @Test
+    public void toString_validUsername_returnsUsername() {
+        String username = "johnwick";
+        TelegramUsername user = new TelegramUsername(username);
+        assertTrue(user.toString().equals(username));
+    }
+
+    @Test
+    public void hashCode_sameUsername_sameHashCode() {
+        String username = "johnwick";
+        TelegramUsername user1 = new TelegramUsername(username);
+        TelegramUsername user2 = new TelegramUsername(username);
+        assertEquals(user1.hashCode(), user2.hashCode());
+    }
+
+    @Test
+    public void hashCode_differentUsername_differentHashCode() {
+        TelegramUsername user1 = new TelegramUsername("johnwick");
+        TelegramUsername user2 = new TelegramUsername("john_wick");
+        assertFalse(user1.hashCode() == user2.hashCode());
+    }
+}

--- a/src/test/java/tuteez/model/person/TelegramUsernameTest.java
+++ b/src/test/java/tuteez/model/person/TelegramUsernameTest.java
@@ -21,6 +21,12 @@ public class TelegramUsernameTest {
     }
 
     @Test
+    public void emptyFactoryMethod_returnsNullUsername() {
+        TelegramUsername emptyUsername = TelegramUsername.empty();
+        assertEquals(emptyUsername.telegramUsername, null);
+    }
+
+    @Test
     public void isValidUsername() {
         // null username
         assertThrows(NullPointerException.class, () -> TelegramUsername.isValidTelegramHandle(null));
@@ -78,6 +84,12 @@ public class TelegramUsernameTest {
         String username = "johnwick";
         TelegramUsername user = TelegramUsername.of(username);
         assertTrue(user.toString().equals(username));
+    }
+
+    @Test
+    public void toString_nullUsername_returnsEmptyString() {
+        TelegramUsername emptyUsername = TelegramUsername.empty();
+        assertEquals(emptyUsername.toString(), "");
     }
 
     @Test

--- a/src/test/java/tuteez/model/person/TelegramUsernameTest.java
+++ b/src/test/java/tuteez/model/person/TelegramUsernameTest.java
@@ -10,14 +10,14 @@ import org.junit.jupiter.api.Test;
 public class TelegramUsernameTest {
 
     @Test
-    public void constructor_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new TelegramUsername(null));
+    public void ofFactoryMethod_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> TelegramUsername.of(null));
     }
 
     @Test
-    public void constructor_invalidUsername_throwsIllegalArgumentException() {
+    public void ofFactoryMethod_invalidUsername_throwsIllegalArgumentException() {
         String invalidUsername = "john wick$";
-        assertThrows(IllegalArgumentException.class, () -> new TelegramUsername(invalidUsername));
+        assertThrows(IllegalArgumentException.class, () -> TelegramUsername.of(invalidUsername));
     }
 
     @Test
@@ -49,10 +49,10 @@ public class TelegramUsernameTest {
 
     @Test
     public void equals() {
-        TelegramUsername user1 = new TelegramUsername("johnwick");
-        TelegramUsername user2 = new TelegramUsername("johnwick");
-        TelegramUsername user3 = new TelegramUsername("john_wick");
-        TelegramUsername user4 = new TelegramUsername("JohnWick");
+        TelegramUsername user1 = TelegramUsername.of("johnwick");
+        TelegramUsername user2 = TelegramUsername.of("johnwick");
+        TelegramUsername user3 = TelegramUsername.of("john_wick");
+        TelegramUsername user4 = TelegramUsername.of("JohnWick");
 
         // same object -> returns true
         assertTrue(user1.equals(user1));
@@ -76,22 +76,22 @@ public class TelegramUsernameTest {
     @Test
     public void toString_validUsername_returnsUsername() {
         String username = "johnwick";
-        TelegramUsername user = new TelegramUsername(username);
+        TelegramUsername user = TelegramUsername.of(username);
         assertTrue(user.toString().equals(username));
     }
 
     @Test
     public void hashCode_sameUsername_sameHashCode() {
         String username = "johnwick";
-        TelegramUsername user1 = new TelegramUsername(username);
-        TelegramUsername user2 = new TelegramUsername(username);
+        TelegramUsername user1 = TelegramUsername.of(username);
+        TelegramUsername user2 = TelegramUsername.of(username);
         assertEquals(user1.hashCode(), user2.hashCode());
     }
 
     @Test
     public void hashCode_differentUsername_differentHashCode() {
-        TelegramUsername user1 = new TelegramUsername("johnwick");
-        TelegramUsername user2 = new TelegramUsername("john_wick");
+        TelegramUsername user1 = TelegramUsername.of("johnwick");
+        TelegramUsername user2 = TelegramUsername.of("john_wick");
         assertFalse(user1.hashCode() == user2.hashCode());
     }
 }

--- a/src/test/java/tuteez/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/tuteez/storage/JsonAdaptedPersonTest.java
@@ -16,18 +16,21 @@ import tuteez.model.person.Address;
 import tuteez.model.person.Email;
 import tuteez.model.person.Name;
 import tuteez.model.person.Phone;
+import tuteez.model.person.TelegramUsername;
 
 public class JsonAdaptedPersonTest {
     private static final String INVALID_NAME = "R@chel";
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
+    private static final String INVALID_TELEGRAM = "33user$";
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
     private static final String VALID_ADDRESS = BENSON.getAddress().toString();
+    private static final String VALID_TELEGRAM = BENSON.getTelegramUsername().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
@@ -41,14 +44,16 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                        VALID_TELEGRAM, VALID_TAGS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                VALID_TELEGRAM, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -56,14 +61,16 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                        VALID_TELEGRAM, VALID_TAGS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS,
+                VALID_TELEGRAM, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -71,14 +78,16 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS,
+                        VALID_TELEGRAM, VALID_TAGS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS,
+                VALID_TELEGRAM, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -86,14 +95,16 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS,
+                        VALID_TELEGRAM, VALID_TAGS);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null,
+                VALID_TELEGRAM, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -103,8 +114,17 @@ public class JsonAdaptedPersonTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                        VALID_TELEGRAM, invalidTags);
         assertThrows(IllegalValueException.class, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidTelegram_throwsIllegalValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                INVALID_TELEGRAM, VALID_TAGS);
+        String expectedMessage = TelegramUsername.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
 }

--- a/src/test/java/tuteez/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/tuteez/storage/JsonAdaptedPersonTest.java
@@ -49,26 +49,16 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-<<<<<<< HEAD
                 new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_TELEGRAM, VALID_TAGS);
-=======
-                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL,
-                        VALID_ADDRESS, VALID_TAGS, VALID_LESSONS);
->>>>>>> upstream/master
+                        VALID_TELEGRAM, VALID_TAGS, VALID_LESSONS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-<<<<<<< HEAD
         JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_TELEGRAM, VALID_TAGS);
-=======
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_LESSONS);
->>>>>>> upstream/master
+                VALID_TELEGRAM, VALID_TAGS, VALID_LESSONS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -76,25 +66,16 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-<<<<<<< HEAD
                 new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_TELEGRAM, VALID_TAGS);
-=======
-                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_LESSONS);
->>>>>>> upstream/master
+                        VALID_TELEGRAM, VALID_TAGS, VALID_LESSONS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
-<<<<<<< HEAD
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS,
-                VALID_TELEGRAM, VALID_TAGS);
-=======
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_LESSONS);
->>>>>>> upstream/master
+                VALID_TELEGRAM, VALID_TAGS, VALID_LESSONS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -102,25 +83,16 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-<<<<<<< HEAD
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS,
-                        VALID_TELEGRAM, VALID_TAGS);
-=======
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_LESSONS);
->>>>>>> upstream/master
+                        VALID_TELEGRAM, VALID_TAGS, VALID_LESSONS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
-<<<<<<< HEAD
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS,
-                VALID_TELEGRAM, VALID_TAGS);
-=======
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS, VALID_LESSONS);
->>>>>>> upstream/master
+                VALID_TELEGRAM, VALID_TAGS, VALID_LESSONS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -128,25 +100,16 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-<<<<<<< HEAD
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS,
-                        VALID_TELEGRAM, VALID_TAGS);
-=======
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS, VALID_LESSONS);
->>>>>>> upstream/master
+                        VALID_TELEGRAM, VALID_TAGS, VALID_LESSONS);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-<<<<<<< HEAD
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null,
-                VALID_TELEGRAM, VALID_TAGS);
-=======
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS, VALID_LESSONS);
->>>>>>> upstream/master
+                VALID_TELEGRAM, VALID_TAGS, VALID_LESSONS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -156,11 +119,8 @@ public class JsonAdaptedPersonTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
-<<<<<<< HEAD
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_TELEGRAM, invalidTags);
-=======
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags, VALID_LESSONS);
+                        VALID_TELEGRAM, invalidTags, VALID_LESSONS);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 
@@ -169,15 +129,15 @@ public class JsonAdaptedPersonTest {
         List<JsonAdaptedLesson> invalidLessons = new ArrayList<>(VALID_LESSONS);
         invalidLessons.add(new JsonAdaptedLesson(INVALID_LESSON));
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, invalidLessons);
->>>>>>> upstream/master
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                        VALID_TELEGRAM, VALID_TAGS, invalidLessons);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 
     @Test
     public void toModelType_invalidTelegram_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                INVALID_TELEGRAM, VALID_TAGS);
+                INVALID_TELEGRAM, VALID_TAGS, VALID_LESSONS);
         String expectedMessage = TelegramUsername.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }

--- a/src/test/java/tuteez/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/tuteez/testutil/EditPersonDescriptorBuilder.java
@@ -10,6 +10,7 @@ import tuteez.model.person.Email;
 import tuteez.model.person.Name;
 import tuteez.model.person.Person;
 import tuteez.model.person.Phone;
+import tuteez.model.person.TelegramUsername;
 import tuteez.model.tag.Tag;
 
 /**
@@ -36,6 +37,7 @@ public class EditPersonDescriptorBuilder {
         descriptor.setPhone(person.getPhone());
         descriptor.setEmail(person.getEmail());
         descriptor.setAddress(person.getAddress());
+        descriptor.setTelegramUsername(person.getTelegramUsername());
         descriptor.setTags(person.getTags());
     }
 
@@ -68,6 +70,18 @@ public class EditPersonDescriptorBuilder {
      */
     public EditPersonDescriptorBuilder withAddress(String address) {
         descriptor.setAddress(new Address(address));
+        return this;
+    }
+
+    /**
+     * Sets the {@code TelegramUsername} of the {@code EditPersonDescriptor} that we are building.
+     */
+    public EditPersonDescriptorBuilder withTelegram(String username) {
+        if (username == null) {
+            descriptor.setTelegramUsername(TelegramUsername.empty());
+        } else {
+            descriptor.setTelegramUsername(TelegramUsername.of(username));
+        }
         return this;
     }
 

--- a/src/test/java/tuteez/testutil/PersonBuilder.java
+++ b/src/test/java/tuteez/testutil/PersonBuilder.java
@@ -8,6 +8,7 @@ import tuteez.model.person.Email;
 import tuteez.model.person.Name;
 import tuteez.model.person.Person;
 import tuteez.model.person.Phone;
+import tuteez.model.person.TelegramUsername;
 import tuteez.model.tag.Tag;
 import tuteez.model.util.SampleDataUtil;
 
@@ -20,11 +21,13 @@ public class PersonBuilder {
     public static final String DEFAULT_PHONE = "85355255";
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
+    public static final String DEFAULT_TELEGRAM = "amy_bee";
 
     private Name name;
     private Phone phone;
     private Email email;
     private Address address;
+    private TelegramUsername telegramUsername;
     private Set<Tag> tags;
 
     /**
@@ -35,6 +38,7 @@ public class PersonBuilder {
         phone = new Phone(DEFAULT_PHONE);
         email = new Email(DEFAULT_EMAIL);
         address = new Address(DEFAULT_ADDRESS);
+        telegramUsername = TelegramUsername.of(DEFAULT_TELEGRAM);
         tags = new HashSet<>();
     }
 
@@ -46,6 +50,7 @@ public class PersonBuilder {
         phone = personToCopy.getPhone();
         email = personToCopy.getEmail();
         address = personToCopy.getAddress();
+        telegramUsername = personToCopy.getTelegramUsername();
         tags = new HashSet<>(personToCopy.getTags());
     }
 
@@ -89,8 +94,20 @@ public class PersonBuilder {
         return this;
     }
 
+    /**
+     * Sets the {@code TelegramUsername} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withTelegram(String telegramUsername) {
+        if (telegramUsername == null) {
+            this.telegramUsername = TelegramUsername.empty();
+        } else {
+            this.telegramUsername = TelegramUsername.of(telegramUsername);
+        }
+        return this;
+    }
+
     public Person build() {
-        return new Person(name, phone, email, address, tags);
+        return new Person(name, phone, email, address, telegramUsername, tags);
     }
 
 }

--- a/src/test/java/tuteez/testutil/PersonUtil.java
+++ b/src/test/java/tuteez/testutil/PersonUtil.java
@@ -5,6 +5,7 @@ import static tuteez.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static tuteez.logic.parser.CliSyntax.PREFIX_NAME;
 import static tuteez.logic.parser.CliSyntax.PREFIX_PHONE;
 import static tuteez.logic.parser.CliSyntax.PREFIX_TAG;
+import static tuteez.logic.parser.CliSyntax.PREFIX_TELEGRAM;
 
 import java.util.Set;
 
@@ -34,6 +35,7 @@ public class PersonUtil {
         sb.append(PREFIX_PHONE + person.getPhone().value + " ");
         sb.append(PREFIX_EMAIL + person.getEmail().value + " ");
         sb.append(PREFIX_ADDRESS + person.getAddress().value + " ");
+        sb.append(PREFIX_TELEGRAM + person.getTelegramUsername().telegramUsername + " ");
         person.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.tagName + " ")
         );
@@ -49,6 +51,8 @@ public class PersonUtil {
         descriptor.getPhone().ifPresent(phone -> sb.append(PREFIX_PHONE).append(phone.value).append(" "));
         descriptor.getEmail().ifPresent(email -> sb.append(PREFIX_EMAIL).append(email.value).append(" "));
         descriptor.getAddress().ifPresent(address -> sb.append(PREFIX_ADDRESS).append(address.value).append(" "));
+        descriptor.getTelegramUsername().ifPresent(username -> sb.append(PREFIX_TELEGRAM)
+                .append(username.telegramUsername).append(" "));
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {

--- a/src/test/java/tuteez/testutil/TypicalPersons.java
+++ b/src/test/java/tuteez/testutil/TypicalPersons.java
@@ -25,22 +25,27 @@ public class TypicalPersons {
 
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
-            .withPhone("94351253")
+            .withPhone("94351253").withTelegram("alice_pauline")
             .withTags("friends").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
-            .withEmail("johnd@example.com").withPhone("98765432")
+            .withEmail("johnd@example.com").withPhone("98765432").withTelegram("benson_meier")
             .withTags("owesMoney", "friends").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
-            .withEmail("heinz@example.com").withAddress("wall street").build();
+            .withEmail("heinz@example.com").withAddress("wall street")
+            .withTelegram("carl_kurz").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
-            .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends").build();
+            .withEmail("cornelia@example.com").withAddress("10th street")
+            .withTelegram("daniel_meier").withTags("friends").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
-            .withEmail("werner@example.com").withAddress("michegan ave").build();
+            .withEmail("werner@example.com").withAddress("michegan ave")
+            .withTelegram("elle_meyer").build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
-            .withEmail("lydia@example.com").withAddress("little tokyo").build();
+            .withEmail("lydia@example.com").withAddress("little tokyo")
+            .withTelegram("fiona_kunz").build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
-            .withEmail("anna@example.com").withAddress("4th street").build();
+            .withEmail("anna@example.com").withAddress("4th street")
+            .withTelegram("george_best").build();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
@@ -50,9 +55,11 @@ public class TypicalPersons {
 
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
-            .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_FRIEND).build();
+            .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_FRIEND)
+            .withTelegram("amy_bee").build();
     public static final Person BOB = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
             .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
+            .withTelegram("bob_choo")
             .build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER


### PR DESCRIPTION
-Fixes #62 

### What is this pull request for?
As a tutor, it is important to be able to contact the student through more than one mode of communication, and since Telegram is a social media platform (which students are likely to use), we allow the tutor to be able to add the student's Telegram handle as part of their contact details when they add a student. However, since we are not certain that every student uses the Telegram application for communication, we allow the field to be optional. 

### What does this pull request do?
- Implement the logic for Telegram usernames by creating classes of its own
- Update the Add and Edit command classes to handle the logic for Telegram usernames. Particularly, the prefix for the command of adding/editing telegram usernames is `/tg`.
- Update the Add and Edit command parsers to be able to parse Telegram usernames
- Update the UI to show the telegram usernames (if added) below the student's phone numbers in the form of "`@username`"
- Fix test cases to allow for Telegram usernames to be added and/or edited

### Notes:
-Currently, `edit INDEX /tg` does not allow the telegram usernames to be edited to blank. Might need to think of whether it would be good/bad to allow the edit command to delete the field for telegram username.
