### PR TITLE
Add `LessonManager` to `Addressbook` & reject clashing lessons

### DIFF
--- a/src/main/java/tuteez/logic/commands/AddCommand.java
+++ b/src/main/java/tuteez/logic/commands/AddCommand.java
@@ -79,10 +79,6 @@ public class AddCommand extends Command {
         model.addPerson(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
     }
-//
-//    public boolean checkForClashingLesson(Lesson lesson) {
-//        return Lesson.isDuplicateLesson(lesson);
-//    }
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/tuteez/logic/commands/AddCommand.java
+++ b/src/main/java/tuteez/logic/commands/AddCommand.java
@@ -71,19 +71,18 @@ public class AddCommand extends Command {
 
         Set<Lesson> lessonSet = toAdd.getLessons();
         for (Lesson lesson: lessonSet) {
-            if (checkForClashingLesson(lesson)) {
+            if (model.isClashingWithExistingLesson(lesson)) {
                 throw new CommandException(MESSAGE_DUPLICATE_LESSON);
             }
         }
 
-        Lesson.addAllLesson(lessonSet);
         model.addPerson(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
     }
-
-    public boolean checkForClashingLesson(Lesson lesson) {
-        return Lesson.isDuplicateLesson(lesson);
-    }
+//
+//    public boolean checkForClashingLesson(Lesson lesson) {
+//        return Lesson.isDuplicateLesson(lesson);
+//    }
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/tuteez/logic/commands/EditCommand.java
+++ b/src/main/java/tuteez/logic/commands/EditCommand.java
@@ -109,10 +109,6 @@ public class EditCommand extends Command {
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
     }
 
-//    public boolean checkForClashingLesson(Lesson lesson) {
-//        return Lesson.isDuplicateLesson(lesson);
-//    }
-
     /**
      * Creates and returns a {@code Person} with the details of {@code personToEdit}
      * edited with {@code editPersonDescriptor}.

--- a/src/main/java/tuteez/logic/commands/EditCommand.java
+++ b/src/main/java/tuteez/logic/commands/EditCommand.java
@@ -97,23 +97,21 @@ public class EditCommand extends Command {
                     continue;
                 }
 
-                if (checkForClashingLesson(newLesson)) {
+                if (model.isClashingWithExistingLesson(newLesson)) {
                     throw new CommandException(MESSAGE_DUPLICATE_LESSON);
                     //return new CommandResult(MESSAGE_DUPLICATE_LESSON, false, false, false);
                 }
             }
         }
 
-        Lesson.removeAllLesson(personToEdit.getLessons());
-        Lesson.addAllLesson(editPersonDescriptor.getLessons().orElse(Collections.emptySet()));
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
     }
 
-    public boolean checkForClashingLesson(Lesson lesson) {
-        return Lesson.isDuplicateLesson(lesson);
-    }
+//    public boolean checkForClashingLesson(Lesson lesson) {
+//        return Lesson.isDuplicateLesson(lesson);
+//    }
 
     /**
      * Creates and returns a {@code Person} with the details of {@code personToEdit}

--- a/src/main/java/tuteez/model/Model.java
+++ b/src/main/java/tuteez/model/Model.java
@@ -7,6 +7,7 @@ import javafx.collections.ObservableList;
 import tuteez.commons.core.GuiSettings;
 import tuteez.model.person.Name;
 import tuteez.model.person.Person;
+import tuteez.model.person.lesson.Lesson;
 
 /**
  * The API of the Model component.
@@ -82,6 +83,8 @@ public interface Model {
      * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.
      */
     void setPerson(Person target, Person editedPerson);
+
+    boolean isClashingWithExistingLesson(Lesson lesson);
 
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();

--- a/src/main/java/tuteez/model/ModelManager.java
+++ b/src/main/java/tuteez/model/ModelManager.java
@@ -13,6 +13,7 @@ import tuteez.commons.core.GuiSettings;
 import tuteez.commons.core.LogsCenter;
 import tuteez.model.person.Name;
 import tuteez.model.person.Person;
+import tuteez.model.person.lesson.Lesson;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -121,6 +122,11 @@ public class ModelManager implements Model {
     public Person findPersonByName(Name targetName) {
         requireNonNull(targetName);
         return addressBook.findPersonByName(targetName);
+    }
+
+    @Override
+    public boolean isClashingWithExistingLesson(Lesson lesson) {
+        return addressBook.isClashingWithExistingLesson(lesson);
     }
 
     //=========== Filtered Person List Accessors =============================================================

--- a/src/main/java/tuteez/model/ReadOnlyAddressBook.java
+++ b/src/main/java/tuteez/model/ReadOnlyAddressBook.java
@@ -2,6 +2,7 @@ package tuteez.model;
 
 import javafx.collections.ObservableList;
 import tuteez.model.person.Person;
+import tuteez.model.person.lesson.LessonManager;
 
 /**
  * Unmodifiable view of an address book
@@ -13,5 +14,6 @@ public interface ReadOnlyAddressBook {
      * This list will not contain any duplicate persons.
      */
     ObservableList<Person> getPersonList();
+    LessonManager getLessonManager();
 
 }

--- a/src/main/java/tuteez/model/person/lesson/Day.java
+++ b/src/main/java/tuteez/model/person/lesson/Day.java
@@ -6,6 +6,16 @@ package tuteez.model.person.lesson;
 public enum Day {
     MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY;
 
+    /**
+     * Converts a string representation of a day into the corresponding {@code Day} enum value.
+     *
+     * <p>The string must be in lowercase (e.g., "monday", "tuesday"). If the string does not
+     * match any of the valid days of the week, an exception is thrown.</p>
+     *
+     * @param dayInStr The string representing the day of the week (e.g., "monday").
+     * @return The {@code Day} enum corresponding to the input string.
+     * @throws IllegalArgumentException If the provided string does not match a valid day.
+     */
     public static Day convertDayToEnum(String dayInStr) {
         switch (dayInStr) {
         case "monday":
@@ -23,8 +33,8 @@ public enum Day {
         case "sunday":
             return SUNDAY;
         default:
-            // Should never reach here because we always check for valid date before calling function
-            throw new RuntimeException();
+            // This should not occur because input is validated before calling the method.
+            throw new IllegalArgumentException("Invalid day string: " + dayInStr);
         }
     }
 

--- a/src/main/java/tuteez/model/person/lesson/Day.java
+++ b/src/main/java/tuteez/model/person/lesson/Day.java
@@ -6,4 +6,30 @@ package tuteez.model.person.lesson;
 public enum Day {
     MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY;
 
+    public static Day convertDayToEnum(String dayInStr) {
+        switch (dayInStr) {
+        case "monday":
+            return MONDAY;
+        case "tuesday":
+            return TUESDAY;
+        case "wednesday":
+            return WEDNESDAY;
+        case "thursday":
+            return THURSDAY;
+        case "friday":
+            return FRIDAY;
+        case "saturday":
+            return SATURDAY;
+        case "sunday":
+            return SUNDAY;
+        default:
+            // Should never reach here because we always check for valid date before calling function
+            throw new RuntimeException();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return name();
+    }
 }

--- a/src/main/java/tuteez/model/person/lesson/Lesson.java
+++ b/src/main/java/tuteez/model/person/lesson/Lesson.java
@@ -176,7 +176,7 @@ public class Lesson {
     /**
      * @return A string with only day and time
      */
-    public String dayTimeString() {
+    public String getDayAndTime() {
         return this.toString().replace("[", "").replace("]", "");
     }
 

--- a/src/main/java/tuteez/model/person/lesson/Lesson.java
+++ b/src/main/java/tuteez/model/person/lesson/Lesson.java
@@ -6,6 +6,7 @@ import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -25,8 +26,11 @@ public class Lesson {
 
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HHmm");
     private static final String VALID_TIME_RANGE_REGEX = "([01]?[0-9]|2[0-3])[0-5][0-9]-([01]?[0-9]|2[0-3])[0-5][0-9]";
-    private static final HashSet<Lesson> lessonSet = new HashSet<>();
-    public final String dayAndTime;
+//    private static final HashSet<Lesson> lessonSet = new HashSet<>();
+    private static final DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HHmm");
+    private final Day lessonDay;
+    private final LocalTime startTime;
+    private final LocalTime endTime;
 
 
     /**
@@ -37,7 +41,11 @@ public class Lesson {
     public Lesson(String lesson) {
         requireNonNull(lesson);
         checkArgument(isValidLesson(lesson), MESSAGE_CONSTRAINTS);
-        this.dayAndTime = lesson.toUpperCase();
+        String[] lessonDayTimeArr = lesson.split(" ");
+        String[] timeArr = lessonDayTimeArr[1].split("-");
+        this.lessonDay = Day.convertDayToEnum(lessonDayTimeArr[0].toLowerCase());
+        this.startTime = LocalTime.parse(timeArr[0], timeFormatter);
+        this.endTime = LocalTime.parse(timeArr[1], timeFormatter);
     }
 
     /**
@@ -98,63 +106,75 @@ public class Lesson {
         String timeRange = parts[1];
         return isValidDay(day) && isValidTimeRange(timeRange) && isValidTimeOrder(timeRange);
     }
+//
+//    /**
+//     * Adds a lesson to the HashSet.
+//     *
+//     * @param lesson The lesson to add.
+//     */
+//    public static void addLesson(Lesson lesson) {
+//        lessonSet.add(lesson);
+//    }
+//
+//
+//    /**
+//     * Adds one or more lessons to the HashSet.
+//     *
+//     * @param newLessons Hashset containing lesson / lessons to add.
+//     */
+//    public static void addAllLesson(Set<Lesson> newLessons) {
+//        lessonSet.addAll(newLessons);
+//    }
+//
+//    /**
+//     * Removes a lesson from the HashSet.
+//     *
+//     * @param lesson The lesson to remove.
+//     */
+//    public static void removeLesson(Lesson lesson) {
+//        lessonSet.remove(lesson);
+//    }
+//
+//    /**
+//     * Removes one or more lessons to the HashSet.
+//     *
+//     * @param lessonsToDelete Hashset containing lesson / lessons to add.
+//     */
+//    public static void removeAllLesson(Set<Lesson> lessonsToDelete) {
+//        lessonSet.removeAll(lessonsToDelete);
+//    }
+//
+//    /**
+//     * Checks if the given lesson is a duplicate by checking the HashSet.
+//     *
+//     * @param lesson The lesson to check for duplication.
+//     * @return true if the lesson is a duplicate, false otherwise.
+//     */
+//    public static boolean isDuplicateLesson(Lesson lesson) {
+//        return lessonSet.contains(lesson);
+//    }
+//
+//    public static boolean containsAll(HashSet<Lesson> lessonsToCompare) {
+//        return Lesson.lessonSet.containsAll(lessonsToCompare);
+//    }
+//
+//    /**
+//     * This method is used only for testing. Should not be used elsewhere
+//     */
+//    public static void clearLessonSet() {
+//        Lesson.lessonSet.clear();
+//    }
 
-    /**
-     * Adds a lesson to the HashSet.
-     *
-     * @param lesson The lesson to add.
-     */
-    public static void addLesson(Lesson lesson) {
-        lessonSet.add(lesson);
+    public static boolean isClashingWithOtherLesson(Lesson firstLs, Lesson secondls) {
+         boolean completelyBefore = firstLs.endTime.isBefore(secondls.startTime)
+                 || firstLs.endTime.equals(secondls.startTime);
+         boolean completelyAfter = firstLs.startTime.isAfter(secondls.endTime)
+                 || firstLs.startTime.equals(secondls.endTime);
+         return !(completelyBefore || completelyAfter);
     }
 
-
-    /**
-     * Adds one or more lessons to the HashSet.
-     *
-     * @param newLessons Hashset containing lesson / lessons to add.
-     */
-    public static void addAllLesson(Set<Lesson> newLessons) {
-        lessonSet.addAll(newLessons);
-    }
-
-    /**
-     * Removes a lesson from the HashSet.
-     *
-     * @param lesson The lesson to remove.
-     */
-    public static void removeLesson(Lesson lesson) {
-        lessonSet.remove(lesson);
-    }
-
-    /**
-     * Removes one or more lessons to the HashSet.
-     *
-     * @param lessonsToDelete Hashset containing lesson / lessons to add.
-     */
-    public static void removeAllLesson(Set<Lesson> lessonsToDelete) {
-        lessonSet.removeAll(lessonsToDelete);
-    }
-
-    /**
-     * Checks if the given lesson is a duplicate by checking the HashSet.
-     *
-     * @param lesson The lesson to check for duplication.
-     * @return true if the lesson is a duplicate, false otherwise.
-     */
-    public static boolean isDuplicateLesson(Lesson lesson) {
-        return lessonSet.contains(lesson);
-    }
-
-    public static boolean containsAll(HashSet<Lesson> lessonsToCompare) {
-        return Lesson.lessonSet.containsAll(lessonsToCompare);
-    }
-
-    /**
-     * This method is used only for testing. Should not be used elsewhere
-     */
-    public static void clearLessonSet() {
-        Lesson.lessonSet.clear();
+    public Day getLessonDay() {
+        return lessonDay;
     }
 
     @Override
@@ -168,18 +188,33 @@ public class Lesson {
         }
 
         Lesson otherLesson = (Lesson) other;
-        return dayAndTime.equals(((Lesson) other).dayAndTime);
+        return otherLesson.startTime.equals(this.startTime) && otherLesson.endTime.equals(this.endTime);
     }
 
-    @Override
-    public int hashCode() {
-        return dayAndTime.hashCode();
-    }
+//    @Override
+//    public int hashCode() {
+//        return dayAndTime.hashCode();
+//    }
 
     /**
      * Format state as text for viewing.
      */
     public String toString() {
-        return '[' + dayAndTime + ']';
+        return '[' + lessonDay.toString() + " " + startTime.toString().replace(":","") + "-"
+                + endTime.toString().replace(":", "")+ ']';
+    }
+
+    /**
+     *
+     */
+    public String dayTimeString() {
+        return this.toString().replace("[","").replace("]", "");
+    }
+
+    public static class LessonComparator implements Comparator<Lesson> {
+        @Override
+        public int compare(Lesson o1, Lesson o2) {
+            return o1.startTime.compareTo(o2.startTime);
+        }
     }
 }

--- a/src/main/java/tuteez/model/person/lesson/Lesson.java
+++ b/src/main/java/tuteez/model/person/lesson/Lesson.java
@@ -7,6 +7,7 @@ import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.Objects;
 
 
 /**
@@ -116,6 +117,10 @@ public class Lesson {
      * @return {@code true} if the two lessons overlap in time, otherwise {@code false}.
      */
     public static boolean isClashingWithOtherLesson(Lesson firstLs, Lesson secondLs) {
+        if (!firstLs.lessonDay.equals(secondLs.lessonDay)) {
+            return false;
+        }
+
         boolean completelyBefore = firstLs.endTime.isBefore(secondLs.startTime)
                  || firstLs.endTime.equals(secondLs.startTime);
         boolean completelyAfter = firstLs.startTime.isAfter(secondLs.endTime)
@@ -153,6 +158,11 @@ public class Lesson {
 
         Lesson otherLesson = (Lesson) other;
         return otherLesson.startTime.equals(this.startTime) && otherLesson.endTime.equals(this.endTime);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(lessonDay, startTime, endTime);
     }
 
     /**

--- a/src/main/java/tuteez/model/person/lesson/Lesson.java
+++ b/src/main/java/tuteez/model/person/lesson/Lesson.java
@@ -7,8 +7,6 @@ import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.HashSet;
-import java.util.Set;
 
 
 /**
@@ -26,7 +24,6 @@ public class Lesson {
 
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HHmm");
     private static final String VALID_TIME_RANGE_REGEX = "([01]?[0-9]|2[0-3])[0-5][0-9]-([01]?[0-9]|2[0-3])[0-5][0-9]";
-//    private static final HashSet<Lesson> lessonSet = new HashSet<>();
     private static final DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HHmm");
     private final Day lessonDay;
     private final LocalTime startTime;
@@ -106,77 +103,44 @@ public class Lesson {
         String timeRange = parts[1];
         return isValidDay(day) && isValidTimeRange(timeRange) && isValidTimeOrder(timeRange);
     }
-//
-//    /**
-//     * Adds a lesson to the HashSet.
-//     *
-//     * @param lesson The lesson to add.
-//     */
-//    public static void addLesson(Lesson lesson) {
-//        lessonSet.add(lesson);
-//    }
-//
-//
-//    /**
-//     * Adds one or more lessons to the HashSet.
-//     *
-//     * @param newLessons Hashset containing lesson / lessons to add.
-//     */
-//    public static void addAllLesson(Set<Lesson> newLessons) {
-//        lessonSet.addAll(newLessons);
-//    }
-//
-//    /**
-//     * Removes a lesson from the HashSet.
-//     *
-//     * @param lesson The lesson to remove.
-//     */
-//    public static void removeLesson(Lesson lesson) {
-//        lessonSet.remove(lesson);
-//    }
-//
-//    /**
-//     * Removes one or more lessons to the HashSet.
-//     *
-//     * @param lessonsToDelete Hashset containing lesson / lessons to add.
-//     */
-//    public static void removeAllLesson(Set<Lesson> lessonsToDelete) {
-//        lessonSet.removeAll(lessonsToDelete);
-//    }
-//
-//    /**
-//     * Checks if the given lesson is a duplicate by checking the HashSet.
-//     *
-//     * @param lesson The lesson to check for duplication.
-//     * @return true if the lesson is a duplicate, false otherwise.
-//     */
-//    public static boolean isDuplicateLesson(Lesson lesson) {
-//        return lessonSet.contains(lesson);
-//    }
-//
-//    public static boolean containsAll(HashSet<Lesson> lessonsToCompare) {
-//        return Lesson.lessonSet.containsAll(lessonsToCompare);
-//    }
-//
-//    /**
-//     * This method is used only for testing. Should not be used elsewhere
-//     */
-//    public static void clearLessonSet() {
-//        Lesson.lessonSet.clear();
-//    }
 
-    public static boolean isClashingWithOtherLesson(Lesson firstLs, Lesson secondls) {
-         boolean completelyBefore = firstLs.endTime.isBefore(secondls.startTime)
-                 || firstLs.endTime.equals(secondls.startTime);
-         boolean completelyAfter = firstLs.startTime.isAfter(secondls.endTime)
-                 || firstLs.startTime.equals(secondls.endTime);
-         return !(completelyBefore || completelyAfter);
+    /**
+     * Determines whether two lessons clash in time.
+     * A clash is defined as any overlap in the start and end times of the two lessons.
+     *
+     * <p>Note: Lessons that are back-to-back, meaning one ends exactly when the other starts
+     * (e.g., 19:00-20:00 and 20:00-21:00), are not considered clashing.</p>
+     *
+     * @param firstLs The first {@code Lesson} to compare.
+     * @param secondLs The second {@code Lesson} to compare.
+     * @return {@code true} if the two lessons overlap in time, otherwise {@code false}.
+     */
+    public static boolean isClashingWithOtherLesson(Lesson firstLs, Lesson secondLs) {
+        boolean completelyBefore = firstLs.endTime.isBefore(secondLs.startTime)
+                 || firstLs.endTime.equals(secondLs.startTime);
+        boolean completelyAfter = firstLs.startTime.isAfter(secondLs.endTime)
+                 || firstLs.startTime.equals(secondLs.endTime);
+        return !(completelyBefore || completelyAfter);
     }
 
+    /**
+     * Returns the day on which this lesson occurs.
+     *
+     * @return The {@code Day} enum representing the day of the week for this lesson.
+     */
     public Day getLessonDay() {
         return lessonDay;
     }
 
+    /**
+     * Compares this lesson to another object for equality.
+     * Returns {@code true} if the other object is a {@code Lesson} with the
+     * same start and end times as this lesson.
+     *
+     * @param other The object to compare for equality.
+     * @return {@code true} if the other object is a {@code Lesson} and has the same
+     *         start and end times as this lesson, {@code false} otherwise.
+     */
     @Override
     public boolean equals(Object other) {
         if (other == this) {
@@ -191,27 +155,36 @@ public class Lesson {
         return otherLesson.startTime.equals(this.startTime) && otherLesson.endTime.equals(this.endTime);
     }
 
-//    @Override
-//    public int hashCode() {
-//        return dayAndTime.hashCode();
-//    }
-
     /**
      * Format state as text for viewing.
      */
     public String toString() {
-        return '[' + lessonDay.toString() + " " + startTime.toString().replace(":","") + "-"
-                + endTime.toString().replace(":", "")+ ']';
+        return '[' + lessonDay.toString() + " " + startTime.toString().replace(":", "") + "-"
+                + endTime.toString().replace(":", "") + ']';
     }
 
     /**
      *
      */
     public String dayTimeString() {
-        return this.toString().replace("[","").replace("]", "");
+        return this.toString().replace("[", "").replace("]", "");
     }
 
+    /**
+     * A comparator for {@code Lesson} objects that compares them based on their start times.
+     * This comparator orders lessons in ascending order of their start time.
+     */
     public static class LessonComparator implements Comparator<Lesson> {
+
+        /**
+         * Compares two {@code Lesson} objects by their start times.
+         *
+         * @param o1 The first {@code Lesson} to compare.
+         * @param o2 The second {@code Lesson} to compare.
+         * @return A negative integer, zero, or a positive integer as the start time of the
+         *         first {@code Lesson} is less than, equal to, or greater than the start time
+         *         of the second {@code Lesson}.
+         */
         @Override
         public int compare(Lesson o1, Lesson o2) {
             return o1.startTime.compareTo(o2.startTime);

--- a/src/main/java/tuteez/model/person/lesson/Lesson.java
+++ b/src/main/java/tuteez/model/person/lesson/Lesson.java
@@ -164,7 +164,7 @@ public class Lesson {
     }
 
     /**
-     *
+     * @return A string with only day and time
      */
     public String dayTimeString() {
         return this.toString().replace("[", "").replace("]", "");
@@ -177,16 +177,22 @@ public class Lesson {
     public static class LessonComparator implements Comparator<Lesson> {
 
         /**
-         * Compares two {@code Lesson} objects by their start times.
+         * Compares two {@code Lesson} objects first by their day of the week and then by their start times.
+         *
+         * <p>If the lessons occur on different days, the comparison is based on the day of the week.
+         * If the lessons occur on the same day, the comparison is based on their start times.</p>
          *
          * @param o1 The first {@code Lesson} to compare.
          * @param o2 The second {@code Lesson} to compare.
-         * @return A negative integer, zero, or a positive integer as the start time of the
-         *         first {@code Lesson} is less than, equal to, or greater than the start time
-         *         of the second {@code Lesson}.
+         * @return If first {@code Lesson} is smaller than, equals to or greater than second {@code Lesson}
          */
         @Override
         public int compare(Lesson o1, Lesson o2) {
+            int dayComparison = o1.lessonDay.compareTo(o2.lessonDay);
+            if (dayComparison != 0) {
+                return dayComparison;
+            }
+
             return o1.startTime.compareTo(o2.startTime);
         }
     }

--- a/src/main/java/tuteez/model/person/lesson/LessonManager.java
+++ b/src/main/java/tuteez/model/person/lesson/LessonManager.java
@@ -12,24 +12,51 @@ import java.util.TreeSet;
 public class LessonManager {
     private final HashMap<Day, TreeSet<Lesson>> dayLessonsMap = new HashMap<>(7);
 
+    /**
+     * Constructs a new {@code lessonManager} and initializes an empty schedule
+     *
+     * <p>A {@code TreeSet} of lessons is created for each day of the week, ensuring
+     * that lessons are stored in natural order based on their start time. The comparator
+     * used to order the lessons is {@code Lesson.LessonComparator}.</p>
+     */
     public LessonManager() {
-       for (Day day : Day.values()) {
-           dayLessonsMap.put(day, new TreeSet<>(new Lesson.LessonComparator()));
-       }
+        for (Day day : Day.values()) {
+            dayLessonsMap.put(day, new TreeSet<>(new Lesson.LessonComparator()));
+        }
     }
 
     /**
-     * Note: Should always check for a clashing lesson before calling this method
-     * @param lesson
+     * Adds a lesson to the lesson schedule for the day on which the lesson occurs.
+     *
+     * <p>Note: Ensure that the lesson does not clash with any existing lessons before
+     * calling this method. Clashing lessons should be detected and rejected beforehand.</p>
+     *
+     * @param lesson The {@code Lesson} to be added to the schedule.
      */
     public void addLesson(Lesson lesson) {
         dayLessonsMap.get(lesson.getLessonDay()).add(lesson);
     }
 
+    /**
+     * Deletes a lesson from the lesson schedule for the day on which the lesson occurs.
+     *
+     * @param lesson The {@code Lesson} to be removed from the schedule.
+     */
     public void deleteLesson(Lesson lesson) {
         dayLessonsMap.get(lesson.getLessonDay()).remove(lesson);
     }
 
+    /**
+     * Checks if the given lesson clashes with any existing lesson on the same day.
+     * A clash is determined if there is any overlap in lesson timings with another
+     * lesson already scheduled on the same day.
+     *
+     * <p> Note: Lessons can be back to back i.e. timings 1900-2000 & 2000-2100 do not clash </p>
+     *
+     * @param lesson The lesson to check for potential time conflicts.
+     * @return {@code true} if the lesson clashes with any existing lessons on the same day,
+     *         {@code false} otherwise.
+     */
     public boolean isClashingWithExistingLesson(Lesson lesson) {
         Day lessonDay = lesson.getLessonDay();
         TreeSet<Lesson> lessonsOnDay = dayLessonsMap.get(lessonDay);
@@ -41,6 +68,14 @@ public class LessonManager {
         return false;
     }
 
+    /**
+     * Sets the lessons from a stored {@code LessonManager} instance. Copies all lessons from
+     * the provided {@code dataLessonManager} into this instance, grouping them by day.
+     * Each day's lessons are stored in a {@code TreeSet} to maintain their natural order.
+     *
+     * @param dataLessonManager The {@code LessonManager} containing the lessons from storage
+     *                          to be copied into this instance.
+     */
     public void setLessonsFromStorage(LessonManager dataLessonManager) {
         for (Day day : Day.values()) {
             dayLessonsMap.put(day, new TreeSet<>(dataLessonManager.dayLessonsMap.get(day)));

--- a/src/main/java/tuteez/model/person/lesson/LessonManager.java
+++ b/src/main/java/tuteez/model/person/lesson/LessonManager.java
@@ -1,0 +1,49 @@
+package tuteez.model.person.lesson;
+
+import java.util.HashMap;
+import java.util.TreeSet;
+
+/**
+ * A container for all Lesson instances
+ * Provides:
+ *  1. Methods to add and delete
+ *  2. Check for clashing lessons
+ */
+public class LessonManager {
+    private final HashMap<Day, TreeSet<Lesson>> dayLessonsMap = new HashMap<>(7);
+
+    public LessonManager() {
+       for (Day day : Day.values()) {
+           dayLessonsMap.put(day, new TreeSet<>(new Lesson.LessonComparator()));
+       }
+    }
+
+    /**
+     * Note: Should always check for a clashing lesson before calling this method
+     * @param lesson
+     */
+    public void addLesson(Lesson lesson) {
+        dayLessonsMap.get(lesson.getLessonDay()).add(lesson);
+    }
+
+    public void deleteLesson(Lesson lesson) {
+        dayLessonsMap.get(lesson.getLessonDay()).remove(lesson);
+    }
+
+    public boolean isClashingWithExistingLesson(Lesson lesson) {
+        Day lessonDay = lesson.getLessonDay();
+        TreeSet<Lesson> lessonsOnDay = dayLessonsMap.get(lessonDay);
+        for (Lesson lessonOnDay : lessonsOnDay) {
+            if (Lesson.isClashingWithOtherLesson(lessonOnDay, lesson)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void setLessonsFromStorage(LessonManager dataLessonManager) {
+        for (Day day : Day.values()) {
+            dayLessonsMap.put(day, new TreeSet<>(dataLessonManager.dayLessonsMap.get(day)));
+        }
+    }
+}

--- a/src/main/java/tuteez/storage/JsonAdaptedLesson.java
+++ b/src/main/java/tuteez/storage/JsonAdaptedLesson.java
@@ -24,7 +24,7 @@ public class JsonAdaptedLesson {
      * Converts a given {@code Lesson} into this class for Jackson use.
      */
     public JsonAdaptedLesson(Lesson source) {
-        dayAndTime = source.dayTimeString();
+        dayAndTime = source.getDayAndTime();
     }
 
     @JsonValue

--- a/src/main/java/tuteez/storage/JsonAdaptedLesson.java
+++ b/src/main/java/tuteez/storage/JsonAdaptedLesson.java
@@ -24,7 +24,7 @@ public class JsonAdaptedLesson {
      * Converts a given {@code Lesson} into this class for Jackson use.
      */
     public JsonAdaptedLesson(Lesson source) {
-        dayAndTime = source.dayAndTime;
+        dayAndTime = source.dayTimeString();
     }
 
     @JsonValue

--- a/src/main/java/tuteez/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/tuteez/storage/JsonSerializableAddressBook.java
@@ -53,7 +53,7 @@ class JsonSerializableAddressBook {
             if (addressBook.hasPerson(person)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
             }
-            Lesson.addAllLesson(person.getLessons());
+//            Lesson.addAllLesson(person.getLessons());
             addressBook.addPerson(person);
         }
         return addressBook;

--- a/src/main/java/tuteez/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/tuteez/storage/JsonSerializableAddressBook.java
@@ -12,7 +12,6 @@ import tuteez.commons.exceptions.IllegalValueException;
 import tuteez.model.AddressBook;
 import tuteez.model.ReadOnlyAddressBook;
 import tuteez.model.person.Person;
-import tuteez.model.person.lesson.Lesson;
 
 /**
  * An Immutable AddressBook that is serializable to JSON format.
@@ -53,7 +52,6 @@ class JsonSerializableAddressBook {
             if (addressBook.hasPerson(person)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
             }
-//            Lesson.addAllLesson(person.getLessons());
             addressBook.addPerson(person);
         }
         return addressBook;

--- a/src/main/java/tuteez/ui/PersonCard.java
+++ b/src/main/java/tuteez/ui/PersonCard.java
@@ -69,7 +69,7 @@ public class PersonCard extends UiPart<Region> {
                 .forEach(remark -> remarks.getChildren().add(new Label(remark.toString())));
 
         person.getLessons().stream()
-                .forEach(lesson -> lessons.getChildren().add(new Label(lesson.dayTimeString())));
+                .forEach(lesson -> lessons.getChildren().add(new Label(lesson.getDayAndTime())));
     }
 
     private void setTelegramUsernameText(Person person) {

--- a/src/main/java/tuteez/ui/PersonCard.java
+++ b/src/main/java/tuteez/ui/PersonCard.java
@@ -69,7 +69,7 @@ public class PersonCard extends UiPart<Region> {
                 .forEach(remark -> remarks.getChildren().add(new Label(remark.toString())));
 
         person.getLessons().stream()
-                .forEach(lesson -> lessons.getChildren().add(new Label(lesson.dayAndTime)));
+                .forEach(lesson -> lessons.getChildren().add(new Label(lesson.dayTimeString())));
     }
 
     private void setTelegramUsernameText(Person person) {

--- a/src/test/java/tuteez/model/AddressBookTest.java
+++ b/src/test/java/tuteez/model/AddressBookTest.java
@@ -20,6 +20,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import tuteez.model.person.Person;
 import tuteez.model.person.exceptions.DuplicatePersonException;
+import tuteez.model.person.lesson.LessonManager;
 import tuteez.testutil.PersonBuilder;
 
 public class AddressBookTest {
@@ -94,6 +95,7 @@ public class AddressBookTest {
      */
     private static class AddressBookStub implements ReadOnlyAddressBook {
         private final ObservableList<Person> persons = FXCollections.observableArrayList();
+        private final LessonManager lessonManager = new LessonManager();
 
         AddressBookStub(Collection<Person> persons) {
             this.persons.setAll(persons);
@@ -102,6 +104,11 @@ public class AddressBookTest {
         @Override
         public ObservableList<Person> getPersonList() {
             return persons;
+        }
+
+        @Override
+        public LessonManager getLessonManager() {
+            return lessonManager;
         }
     }
 

--- a/src/test/java/tuteez/model/person/lesson/LessonManagerTest.java
+++ b/src/test/java/tuteez/model/person/lesson/LessonManagerTest.java
@@ -1,10 +1,9 @@
 package tuteez.model.person.lesson;
 
-
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
 
 public class LessonManagerTest {
 

--- a/src/test/java/tuteez/model/person/lesson/LessonManagerTest.java
+++ b/src/test/java/tuteez/model/person/lesson/LessonManagerTest.java
@@ -1,0 +1,46 @@
+package tuteez.model.person.lesson;
+
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LessonManagerTest {
+
+    @Test
+    public void addLesson() {
+        LessonManager lessonManager = new LessonManager();
+        Lesson l1 = new Lesson("friday 1200-1400");
+        lessonManager.addLesson(l1);
+        assertTrue(lessonManager.isClashingWithExistingLesson(l1));
+    }
+
+    @Test
+    public void deleteLesson() {
+        LessonManager lessonManager = new LessonManager();
+        Lesson l1 = new Lesson("friday 1200-1400");
+        lessonManager.addLesson(l1);
+        assertTrue(lessonManager.isClashingWithExistingLesson(l1));
+        lessonManager.deleteLesson(l1);
+        assertFalse(lessonManager.isClashingWithExistingLesson(l1));
+    }
+
+    @Test
+    public void isClashingWithExistingLesson_clashOccurs() {
+        LessonManager lessonManager = new LessonManager();
+        Lesson l1 = new Lesson("friday 1200-1400");
+        Lesson l2 = new Lesson("friday 1230-1430");
+        lessonManager.addLesson(l1);
+        assertTrue(lessonManager.isClashingWithExistingLesson(l2));
+    }
+
+    @Test
+    public void isClashingWithExistingLesson_noClash() {
+        LessonManager lessonManager = new LessonManager();
+        Lesson l1 = new Lesson("friday 1200-1400");
+        Lesson l2 = new Lesson("friday 1400-1500");
+        lessonManager.addLesson(l1);
+        assertFalse(lessonManager.isClashingWithExistingLesson(l2));
+    }
+}

--- a/src/test/java/tuteez/model/person/lesson/LessonTest.java
+++ b/src/test/java/tuteez/model/person/lesson/LessonTest.java
@@ -1,7 +1,11 @@
 package tuteez.model.person.lesson;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static tuteez.testutil.Assert.assertThrows;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 
@@ -14,5 +18,58 @@ public class LessonTest {
     public void constructor_startTimeAfterEndTime_throwsIllegalArgumentException() {
         String invalidTimeStr = "friday 1800-1700";
         assertThrows(IllegalArgumentException.class, () -> new Lesson(invalidTimeStr));
+    }
+
+    @Test
+    public void isClashingWithOtherLessonTest_noClash() {
+        Lesson l1 = new Lesson("Friday 1300-1400");
+        Lesson l2 = new Lesson("Friday 1400-1500");
+        Lesson l3 = new Lesson("Thursday 1300-1400");
+        Lesson l4 = new Lesson("Thursday 1600-1700");
+
+        assertFalse(Lesson.isClashingWithOtherLesson(l1, l2));
+        assertFalse(Lesson.isClashingWithOtherLesson(l2, l1));
+        assertFalse(Lesson.isClashingWithOtherLesson(l1, l3));
+        assertFalse(Lesson.isClashingWithOtherLesson(l3, l4));
+    }
+
+    @Test
+    public void isClashingWithOtherLessonTest_clashOccur() {
+        Lesson l1 = new Lesson("Friday 1300-1400");
+        Lesson l2 = new Lesson("Friday 1330-1430");
+
+        Lesson l3 = new Lesson("Thursday 1200-1300");
+        Lesson l4 = new Lesson("Thursday 1100-1400");
+
+
+        Lesson l5 = new Lesson("Wednesday 1100-1200");
+        Lesson l6 = new Lesson("Wednesday 1100-1200");
+
+        assertTrue(Lesson.isClashingWithOtherLesson(l1, l2));
+        assertTrue(Lesson.isClashingWithOtherLesson(l2, l1));
+        assertTrue(Lesson.isClashingWithOtherLesson(l3, l4));
+        assertTrue(Lesson.isClashingWithOtherLesson(l5, l6));
+    }
+
+    @Test
+    public void equals() {
+        Lesson l1 = new Lesson("Friday 1300-1400");
+        Lesson l2 = new Lesson("Friday 1300-1400");
+        Lesson l3 = new Lesson("friday 1300-1400");
+
+        Assertions.assertNotEquals(l1, new Object());
+        assertEquals(l1, l1);
+        assertEquals(l1, l2);
+        assertEquals(l2, l3);
+    }
+
+    @Test
+    public void lessonComparatorTest() {
+        Lesson.LessonComparator lessonComparator = new Lesson.LessonComparator();
+        Lesson l1 = new Lesson("Monday 1300-1400");
+        Lesson l2 = new Lesson("Tuesday 1300-1400");
+        Lesson l3 = new Lesson("Tuesday 1400-1500");
+        assertEquals(-1, lessonComparator.compare(l1, l2));
+        assertEquals(-1, lessonComparator.compare(l2, l3));
     }
 }

--- a/src/test/java/tuteez/testutil/PersonUtil.java
+++ b/src/test/java/tuteez/testutil/PersonUtil.java
@@ -42,7 +42,7 @@ public class PersonUtil {
             s -> sb.append(PREFIX_TAG + s.tagName + " ")
         );
         person.getLessons().stream().forEach(
-                s -> sb.append(PREFIX_LESSON + s.dayTimeString() + " ")
+                s -> sb.append(PREFIX_LESSON + s.getDayAndTime() + " ")
         );
         return sb.toString();
     }
@@ -71,7 +71,7 @@ public class PersonUtil {
             if (lessons.isEmpty()) {
                 sb.append(PREFIX_LESSON);
             } else {
-                lessons.forEach(s -> sb.append(PREFIX_LESSON).append(s.dayTimeString()).append(" "));
+                lessons.forEach(s -> sb.append(PREFIX_LESSON).append(s.getDayAndTime()).append(" "));
             }
         }
         return sb.toString();

--- a/src/test/java/tuteez/testutil/PersonUtil.java
+++ b/src/test/java/tuteez/testutil/PersonUtil.java
@@ -42,7 +42,7 @@ public class PersonUtil {
             s -> sb.append(PREFIX_TAG + s.tagName + " ")
         );
         person.getLessons().stream().forEach(
-                s -> sb.append(PREFIX_LESSON + s.dayAndTime + " ")
+                s -> sb.append(PREFIX_LESSON + s.dayTimeString() + " ")
         );
         return sb.toString();
     }
@@ -71,7 +71,7 @@ public class PersonUtil {
             if (lessons.isEmpty()) {
                 sb.append(PREFIX_LESSON);
             } else {
-                lessons.forEach(s -> sb.append(PREFIX_LESSON).append(s.dayAndTime).append(" "));
+                lessons.forEach(s -> sb.append(PREFIX_LESSON).append(s.dayTimeString()).append(" "));
             }
         }
         return sb.toString();


### PR DESCRIPTION
Resolve #76 

## What is this PR for? 
In previous version lessons are only rejected when they have a 1:1 overlap in lesson time. Meaning a lesson on `Thursday 0800-0900` another lesson on `Thursday 0800-0900` cannot be added. However `Thursday 0830-0930` can be added but it is clearly a clashing lesson.  

## What does this PR do? 
Allows detection of clashing lessons. In the above example, all 3 lessons will clash

## Notes: 
Lesson with start times coinciding with another lesson's are not considered overlapping vice versa. E.g. `Monday 1300-1400` & `Monday 1400-1500` do not clash