### PR TITLE
Add abbreviations for `delete` and `remark`

### DIFF
--- a/src/main/java/tuteez/logic/commands/DeleteCommand.java
+++ b/src/main/java/tuteez/logic/commands/DeleteCommand.java
@@ -20,11 +20,10 @@ public class DeleteCommand extends Command {
     public static final String COMMAND_WORD = "delete";
     public static final String COMMAND_WORD_ALT = "del";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + " | " + COMMAND_WORD_ALT
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " (short form: " + COMMAND_WORD_ALT + ")"
             + ": Deletes the person identified by the index number used in the displayed person list or by name.\n"
             + "Parameters: INDEX (must be a positive integer) or NAME (must be a valid name in the addressbook)\n"
-            + "Example: " + COMMAND_WORD + " 1" + " | " + COMMAND_WORD + " John Doe" + " | "
-            + COMMAND_WORD_ALT + " 1" + " | " + COMMAND_WORD_ALT + " John Doe";
+            + "Example: " + COMMAND_WORD + " 1" + " or " + COMMAND_WORD + " John Doe";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
 

--- a/src/main/java/tuteez/logic/commands/DeleteCommand.java
+++ b/src/main/java/tuteez/logic/commands/DeleteCommand.java
@@ -18,11 +18,13 @@ import tuteez.model.person.Person;
 public class DeleteCommand extends Command {
 
     public static final String COMMAND_WORD = "delete";
+    public static final String COMMAND_WORD_ALT = "del";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " | " + COMMAND_WORD_ALT
             + ": Deletes the person identified by the index number used in the displayed person list or by name.\n"
             + "Parameters: INDEX (must be a positive integer) or NAME (must be a valid name in the addressbook)\n"
-            + "Example: " + COMMAND_WORD + " 1" + " or " + COMMAND_WORD + " John Doe";
+            + "Example: " + COMMAND_WORD + " 1" + " | " + COMMAND_WORD + " John Doe" + " | "
+            + COMMAND_WORD_ALT + " 1" + " | " + COMMAND_WORD_ALT + " John Doe";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
 

--- a/src/main/java/tuteez/logic/commands/RemarkCommand.java
+++ b/src/main/java/tuteez/logic/commands/RemarkCommand.java
@@ -18,13 +18,12 @@ public abstract class RemarkCommand extends Command {
     public static final String COMMAND_WORD = "remark";
     public static final String COMMAND_WORD_ALT = "rmk";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + " | " + COMMAND_WORD_ALT
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " (short form: " + COMMAND_WORD_ALT + ")"
             + ": Adds or deletes a remark for the student identified by the index number in the displayed student list."
-            + "\nParameters: INDEX -a REMARK | INDEX -d REMARK_INDEX\n"
-            + "Example to add remark: " + COMMAND_WORD + " 1 -a This is a new remark | "
-            + COMMAND_WORD_ALT + " 1 -a This is a new remark\n"
-            + "Example to delete remark: " + COMMAND_WORD + " 1 -d 2 | "
-            + COMMAND_WORD_ALT + " 1 -d 2";
+            + "\nParameters: INDEX (must be a positive integer) -a REMARK or "
+            + "-d REMARK_INDEX (must be a positive integer)\n"
+            + "Example to add remark: " + COMMAND_WORD + " 1 -a This is a new remark\n"
+            + "Example to delete remark: " + COMMAND_WORD + " 1 -d 2";
 
     protected final Index personIndex;
 

--- a/src/main/java/tuteez/logic/commands/RemarkCommand.java
+++ b/src/main/java/tuteez/logic/commands/RemarkCommand.java
@@ -16,12 +16,15 @@ import tuteez.model.person.Person;
 public abstract class RemarkCommand extends Command {
 
     public static final String COMMAND_WORD = "remark";
-    public static final String MESSAGE_USAGE = COMMAND_WORD
+    public static final String COMMAND_WORD_ALT = "rmk";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " | " + COMMAND_WORD_ALT
             + ": Adds or deletes a remark for the student identified by the index number in the displayed student list."
-            + "Parameters: INDEX (must be a positive integer) "
-            + "[-a ADD_REMARK] | [-d DELETE_REMARK_INDEX]\n"
-            + "Example to add remark: " + COMMAND_WORD + " 1 -a This is a new remark\n"
-            + "Example to delete remark: " + COMMAND_WORD + " 1 -d 2";
+            + "\nParameters: INDEX -a REMARK | INDEX -d REMARK_INDEX\n"
+            + "Example to add remark: " + COMMAND_WORD + " 1 -a This is a new remark | "
+            + COMMAND_WORD_ALT + " 1 -a This is a new remark\n"
+            + "Example to delete remark: " + COMMAND_WORD + " 1 -d 2 | "
+            + COMMAND_WORD_ALT + " 1 -d 2";
 
     protected final Index personIndex;
 

--- a/src/main/java/tuteez/logic/parser/AddressBookParser.java
+++ b/src/main/java/tuteez/logic/parser/AddressBookParser.java
@@ -62,6 +62,7 @@ public class AddressBookParser {
             return new EditCommandParser().parse(arguments);
 
         case DeleteCommand.COMMAND_WORD:
+        case DeleteCommand.COMMAND_WORD_ALT:
             return new DeleteCommandParser().parse(arguments);
 
         case DisplayCommand.COMMAND_WORD:
@@ -83,6 +84,7 @@ public class AddressBookParser {
             return new HelpCommand();
 
         case RemarkCommand.COMMAND_WORD:
+        case RemarkCommand.COMMAND_WORD_ALT:
             return new RemarkCommandParser().parse(arguments);
 
         default:

--- a/src/test/java/tuteez/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/tuteez/logic/parser/AddressBookParserTest.java
@@ -59,6 +59,13 @@ public class AddressBookParserTest {
     }
 
     @Test
+    public void parseCommand_deleteAltCommand() throws Exception {
+        DeleteCommand command = (DeleteCommand) parser.parseCommand(
+                DeleteCommand.COMMAND_WORD_ALT + " " + INDEX_FIRST_PERSON.getOneBased());
+        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
+    }
+
+    @Test
     public void parseCommand_edit() throws Exception {
         Person person = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
@@ -75,6 +82,13 @@ public class AddressBookParserTest {
     }
 
     @Test
+    public void parseCommand_addRemarkAltCommand() throws Exception {
+        AddRemarkCommand command = (AddRemarkCommand) parser.parseCommand(RemarkCommand.COMMAND_WORD_ALT + " "
+                + INDEX_FIRST_PERSON.getOneBased() + " " + AddRemarkCommand.ADD_REMARK_PARAM + " " + "remark");
+        assertEquals(new AddRemarkCommand(INDEX_FIRST_PERSON, new Remark("remark")), command);
+    }
+
+    @Test
     public void parseCommand_deleteRemark() throws Exception {
         DeleteRemarkCommand command = (DeleteRemarkCommand) parser.parseCommand(RemarkCommand.COMMAND_WORD + " "
                 + INDEX_FIRST_PERSON.getOneBased() + " " + DeleteRemarkCommand.DELETE_REMARK_PARAM + " 1");
@@ -82,21 +96,10 @@ public class AddressBookParserTest {
     }
 
     @Test
-    public void parseCommand_invalidRemarkCommand() {
-        assertThrows(ParseException.class, () -> parser.parseCommand(
-                RemarkCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased() + " -x Some remark"));
-    }
-
-    @Test
-    public void parseCommand_remarkWithoutIndex() {
-        assertThrows(ParseException.class, () -> parser.parseCommand(
-                RemarkCommand.COMMAND_WORD + " -a Some remark"));
-    }
-
-    @Test
-    public void parseCommand_remarkWithInvalidIndex() {
-        assertThrows(ParseException.class, () -> parser.parseCommand(
-                RemarkCommand.COMMAND_WORD + " -1 -a Some remark"));
+    public void parseCommand_deleteRemarkAltCommand() throws Exception {
+        DeleteRemarkCommand command = (DeleteRemarkCommand) parser.parseCommand(RemarkCommand.COMMAND_WORD_ALT
+                + " " + INDEX_FIRST_PERSON.getOneBased() + " " + DeleteRemarkCommand.DELETE_REMARK_PARAM + " 1");
+        assertEquals(new DeleteRemarkCommand(INDEX_FIRST_PERSON, INDEX_FIRST_REMARK), command);
     }
 
     @Test


### PR DESCRIPTION
Fixes #81 

## What is this PR for?
Some commands such as `delete` and `remark` are unnecessarily long, which may result in inefficiency for tuition teachers using our app.

## What does this PR do?
Add alternative command words, `del` and `rem`, for `delete` and `remark` respectively

## Notes:
I did not abbreviate `find` -> `f` etc because such abbreviations may be unclear and ambiguous