### PR TITLE
Update Email and Address command fields to be optional when adding contacts

### DIFF
--- a/src/main/java/tuteez/logic/Messages.java
+++ b/src/main/java/tuteez/logic/Messages.java
@@ -47,7 +47,7 @@ public class Messages {
                 .append("; Address: ")
                 .append(person.getAddress())
                 .append("; Telegram: ")
-                .append(person.getTelegramUsername())
+                .append(person.getTelegramUsername().toString())
                 .append("; Tags: ");
         person.getTags().forEach(builder::append);
         builder.append("; Lessons: ");

--- a/src/main/java/tuteez/logic/commands/AddCommand.java
+++ b/src/main/java/tuteez/logic/commands/AddCommand.java
@@ -32,7 +32,7 @@ public class AddCommand extends Command {
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
             + PREFIX_TELEGRAM + "TELEGRAM USERNAME"
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + " [" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "

--- a/src/main/java/tuteez/logic/parser/AddCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/AddCommandParser.java
@@ -38,7 +38,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                         PREFIX_TELEGRAM, PREFIX_TAG, PREFIX_LESSON);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL)
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
@@ -47,8 +47,8 @@ public class AddCommandParser implements Parser<AddCommand> {
                 PREFIX_TELEGRAM);
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
-        Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
-        Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
+        Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).orElse(null));
+        Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).orElse(null));
         TelegramUsername telegramUsername = ParserUtil.parseTelegramUsername(
                 argMultimap.getValue(PREFIX_TELEGRAM).orElse(null));
 

--- a/src/main/java/tuteez/logic/parser/EditCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/EditCommandParser.java
@@ -63,12 +63,10 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
             String email = argMultimap.getValue(PREFIX_EMAIL).get();
             setEditedEmail(editPersonDescriptor, email);
-//            editPersonDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
         }
         if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
             String address = argMultimap.getValue(PREFIX_ADDRESS).get();
             setEditedAddress(editPersonDescriptor, address);
-//            editPersonDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
         }
         if (argMultimap.getValue(PREFIX_TELEGRAM).isPresent()) {
             String telegramUsername = argMultimap.getValue(PREFIX_TELEGRAM).get();

--- a/src/main/java/tuteez/logic/parser/EditCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/EditCommandParser.java
@@ -19,6 +19,8 @@ import tuteez.commons.core.index.Index;
 import tuteez.logic.commands.EditCommand;
 import tuteez.logic.commands.EditCommand.EditPersonDescriptor;
 import tuteez.logic.parser.exceptions.ParseException;
+import tuteez.model.person.Address;
+import tuteez.model.person.Email;
 import tuteez.model.person.TelegramUsername;
 import tuteez.model.person.lesson.Lesson;
 import tuteez.model.tag.Tag;
@@ -59,10 +61,14 @@ public class EditCommandParser implements Parser<EditCommand> {
             editPersonDescriptor.setPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()));
         }
         if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
-            editPersonDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
+            String email = argMultimap.getValue(PREFIX_EMAIL).get();
+            setEditedEmail(editPersonDescriptor, email);
+//            editPersonDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
         }
         if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
-            editPersonDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
+            String address = argMultimap.getValue(PREFIX_ADDRESS).get();
+            setEditedAddress(editPersonDescriptor, address);
+//            editPersonDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
         }
         if (argMultimap.getValue(PREFIX_TELEGRAM).isPresent()) {
             String telegramUsername = argMultimap.getValue(PREFIX_TELEGRAM).get();
@@ -76,6 +82,22 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         return new EditCommand(index, editPersonDescriptor);
+    }
+
+    private void setEditedEmail(EditPersonDescriptor editPersonDescriptor, String email) throws ParseException {
+        if (email.isEmpty()) {
+            editPersonDescriptor.setEmail(new Email(null));
+        } else {
+            editPersonDescriptor.setEmail(ParserUtil.parseEmail(email));
+        }
+    }
+
+    private void setEditedAddress(EditPersonDescriptor editPersonDescriptor, String address) throws ParseException {
+        if (address.isEmpty()) {
+            editPersonDescriptor.setAddress(new Address(null));
+        } else {
+            editPersonDescriptor.setAddress(ParserUtil.parseAddress(address));
+        }
     }
 
     private void setEditedTelegramUsername(EditPersonDescriptor editPersonDescriptor, String telegramUsername)

--- a/src/main/java/tuteez/logic/parser/EditCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/EditCommandParser.java
@@ -19,6 +19,7 @@ import tuteez.commons.core.index.Index;
 import tuteez.logic.commands.EditCommand;
 import tuteez.logic.commands.EditCommand.EditPersonDescriptor;
 import tuteez.logic.parser.exceptions.ParseException;
+import tuteez.model.person.TelegramUsername;
 import tuteez.model.person.lesson.Lesson;
 import tuteez.model.tag.Tag;
 
@@ -64,8 +65,8 @@ public class EditCommandParser implements Parser<EditCommand> {
             editPersonDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
         }
         if (argMultimap.getValue(PREFIX_TELEGRAM).isPresent()) {
-            editPersonDescriptor.setTelegramUsername(ParserUtil.parseTelegramUsername(
-                    argMultimap.getValue(PREFIX_TELEGRAM).get()));
+            String telegramUsername = argMultimap.getValue(PREFIX_TELEGRAM).get();
+            setEditedTelegramUsername(editPersonDescriptor, telegramUsername);
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
         parseLessonsForEdit(argMultimap.getAllValues(PREFIX_LESSON)).ifPresent(editPersonDescriptor::setLessons);
@@ -75,6 +76,15 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         return new EditCommand(index, editPersonDescriptor);
+    }
+
+    private void setEditedTelegramUsername(EditPersonDescriptor editPersonDescriptor, String telegramUsername)
+            throws ParseException {
+        if (telegramUsername.isEmpty()) {
+            editPersonDescriptor.setTelegramUsername(TelegramUsername.empty());
+        } else {
+            editPersonDescriptor.setTelegramUsername(ParserUtil.parseTelegramUsername(telegramUsername));
+        }
     }
 
     /**

--- a/src/main/java/tuteez/logic/parser/ParserUtil.java
+++ b/src/main/java/tuteez/logic/parser/ParserUtil.java
@@ -136,11 +136,13 @@ public class ParserUtil {
             return TelegramUsername.empty();
         }
         String trimmedUsername = username.trim();
+
         if (!TelegramUsername.isValidTelegramHandle(trimmedUsername)) {
             throw new ParseException(TelegramUsername.MESSAGE_CONSTRAINTS);
         }
         return TelegramUsername.of(trimmedUsername);
     }
+
 
     /**
      * Parses a {@code String lesson} into a {@code Lesson}.

--- a/src/main/java/tuteez/logic/parser/ParserUtil.java
+++ b/src/main/java/tuteez/logic/parser/ParserUtil.java
@@ -74,7 +74,9 @@ public class ParserUtil {
      * @throws ParseException if the given {@code address} is invalid.
      */
     public static Address parseAddress(String address) throws ParseException {
-        requireNonNull(address);
+        if (address == null) {
+            return new Address(address);
+        }
         String trimmedAddress = address.trim();
         if (!Address.isValidAddress(trimmedAddress)) {
             throw new ParseException(Address.MESSAGE_CONSTRAINTS);
@@ -89,7 +91,9 @@ public class ParserUtil {
      * @throws ParseException if the given {@code email} is invalid.
      */
     public static Email parseEmail(String email) throws ParseException {
-        requireNonNull(email);
+        if (email == null) {
+            return new Email(email);
+        }
         String trimmedEmail = email.trim();
         if (!Email.isValidEmail(trimmedEmail)) {
             throw new ParseException(Email.MESSAGE_CONSTRAINTS);

--- a/src/main/java/tuteez/model/person/Address.java
+++ b/src/main/java/tuteez/model/person/Address.java
@@ -9,7 +9,8 @@ import static tuteez.commons.util.AppUtil.checkArgument;
  */
 public class Address {
 
-    public static final String MESSAGE_CONSTRAINTS = "Addresses can take any values, and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "Addresses can take any values, and it should not be blank"
+            + ", unless when editing.";
 
     /*
      * The first character of the address must not be a whitespace,
@@ -25,8 +26,11 @@ public class Address {
      * @param address A valid address.
      */
     public Address(String address) {
-        requireNonNull(address);
-        checkArgument(isValidAddress(address), MESSAGE_CONSTRAINTS);
+        // address argument can be null to make it optional
+        if (address != null) {
+            requireNonNull(address);
+            checkArgument(isValidAddress(address), MESSAGE_CONSTRAINTS);
+        }
         value = address;
     }
 
@@ -34,11 +38,17 @@ public class Address {
      * Returns true if a given string is a valid email.
      */
     public static boolean isValidAddress(String test) {
+        if (test == null) {
+            return true;
+        }
         return test.matches(VALIDATION_REGEX);
     }
 
     @Override
     public String toString() {
+        if (value == null) {
+            return "";
+        }
         return value;
     }
 
@@ -54,12 +64,15 @@ public class Address {
         }
 
         Address otherAddress = (Address) other;
+        if (value == null) {
+            return otherAddress.value == null;
+        }
         return value.equals(otherAddress.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return value == null ? 0 : value.hashCode();
     }
 
 }

--- a/src/main/java/tuteez/model/person/Email.java
+++ b/src/main/java/tuteez/model/person/Email.java
@@ -10,7 +10,7 @@ import static tuteez.commons.util.AppUtil.checkArgument;
 public class Email {
 
     private static final String SPECIAL_CHARACTERS = "+_.-";
-    public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
+    public static final String MESSAGE_CONSTRAINTS = "If provided, Emails should be of the format local-part@domain "
             + "and adhere to the following constraints:\n"
             + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
             + "the parentheses, (" + SPECIAL_CHARACTERS + "). The local-part may not start or end with any special "
@@ -39,8 +39,11 @@ public class Email {
      * @param email A valid email address.
      */
     public Email(String email) {
-        requireNonNull(email);
-        checkArgument(isValidEmail(email), MESSAGE_CONSTRAINTS);
+        // email argument can be null to make it optional
+        if (email != null) {
+            requireNonNull(email);
+            checkArgument(isValidEmail(email), MESSAGE_CONSTRAINTS);
+        }
         value = email;
     }
 
@@ -48,11 +51,17 @@ public class Email {
      * Returns if a given string is a valid email.
      */
     public static boolean isValidEmail(String test) {
+        if (test == null) {
+            return true;
+        }
         return test.matches(VALIDATION_REGEX);
     }
 
     @Override
     public String toString() {
+        if (value == null) {
+            return "";
+        }
         return value;
     }
 
@@ -68,12 +77,15 @@ public class Email {
         }
 
         Email otherEmail = (Email) other;
+        if (value == null) {
+            return otherEmail.value == null;
+        }
         return value.equals(otherEmail.value);
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return value == null ? 0 : value.hashCode();
     }
 
 }

--- a/src/main/java/tuteez/model/person/TelegramUsername.java
+++ b/src/main/java/tuteez/model/person/TelegramUsername.java
@@ -14,7 +14,7 @@ public class TelegramUsername {
     public static final String MESSAGE_CONSTRAINTS =
             "Telegram usernames must be at least 5 characters long, and can only contain a-z/A-Z, 0-9, and underscores."
             + " Telegram usernames are case insensitive, and will be in lowercase. It must start with a letter,"
-            + " and should not be blank.";
+            + " and should not be blank unless the user is editing.";
 
     public static final String VALIDATION_REGEX = "^[a-zA-Z][a-zA-Z0-9_]{4,31}$";
 

--- a/src/main/java/tuteez/storage/JsonAdaptedPerson.java
+++ b/src/main/java/tuteez/storage/JsonAdaptedPerson.java
@@ -108,17 +108,11 @@ class JsonAdaptedPerson {
         }
         final Phone modelPhone = new Phone(phone);
 
-        if (email == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName()));
-        }
         if (!Email.isValidEmail(email)) {
             throw new IllegalValueException(Email.MESSAGE_CONSTRAINTS);
         }
         final Email modelEmail = new Email(email);
 
-        if (address == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName()));
-        }
         if (!Address.isValidAddress(address)) {
             throw new IllegalValueException(Address.MESSAGE_CONSTRAINTS);
         }

--- a/src/main/java/tuteez/ui/PersonCard.java
+++ b/src/main/java/tuteez/ui/PersonCard.java
@@ -12,7 +12,7 @@ import tuteez.model.person.Person;
 import tuteez.model.person.TelegramUsername;
 
 /**
- * An UI component that displays information of a {@code Person}.
+ * A UI component that displays information of a {@code Person}.
  */
 public class PersonCard extends UiPart<Region> {
 
@@ -59,8 +59,8 @@ public class PersonCard extends UiPart<Region> {
         name.setText(person.getName().fullName);
         phone.setText(person.getPhone().value);
         setTelegramUsernameText(person);
-        address.setText(person.getAddress().value);
-        email.setText(person.getEmail().value);
+        setAddressText(person);
+        setEmailText(person);
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
@@ -70,6 +70,24 @@ public class PersonCard extends UiPart<Region> {
 
         person.getLessons().stream()
                 .forEach(lesson -> lessons.getChildren().add(new Label(lesson.dayAndTime)));
+    }
+
+    private void setAddressText(Person person) {
+        if (person.getAddress().value != null) {
+            address.setText(person.getAddress().value);
+            address.setVisible(true);
+        } else {
+            address.setVisible(false);
+        }
+    }
+
+    private void setEmailText(Person person) {
+        if (person.getEmail().value != null) {
+            email.setText(person.getEmail().value);
+            email.setVisible(true);
+        } else {
+            email.setVisible(false);
+        }
     }
 
     private void setTelegramUsernameText(Person person) {

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -31,8 +31,8 @@
       <FlowPane fx:id="lessons" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="telegram" styleClass="cell_small_label" text="\$telegram" managed="${telegram.visible}" />
-      <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
-      <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+      <Label fx:id="address" styleClass="cell_small_label" text="\$address" managed ="${address.visible}" />
+      <Label fx:id="email" styleClass="cell_small_label" text="\$email" managed ="${email.visible}" />
       <VBox fx:id="remarks" spacing="5">
       </VBox>
     </VBox>

--- a/src/test/java/tuteez/logic/commands/CommandTestUtil.java
+++ b/src/test/java/tuteez/logic/commands/CommandTestUtil.java
@@ -59,7 +59,8 @@ public class CommandTestUtil {
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James*"; // '*' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
-    public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
+    // empty string not allowed for addresses, only while adding, but not editing.
+    public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS;
     public static final String INVALID_TELEGRAM_DESC = " " + PREFIX_TELEGRAM + "amybee!"; // '!' not allowed in username
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
     public static final String INVALID_LESSON_DESC = " " + PREFIX_LESSON + "monday 10:1100";

--- a/src/test/java/tuteez/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/tuteez/logic/parser/AddCommandParserTest.java
@@ -10,6 +10,7 @@ import static tuteez.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static tuteez.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static tuteez.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static tuteez.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
+import static tuteez.logic.commands.CommandTestUtil.INVALID_TELEGRAM_DESC;
 import static tuteez.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static tuteez.logic.commands.CommandTestUtil.NAME_DESC_BOB;
 import static tuteez.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
@@ -44,6 +45,7 @@ import tuteez.model.person.Email;
 import tuteez.model.person.Name;
 import tuteez.model.person.Person;
 import tuteez.model.person.Phone;
+import tuteez.model.person.TelegramUsername;
 import tuteez.model.tag.Tag;
 import tuteez.testutil.PersonBuilder;
 
@@ -192,6 +194,10 @@ public class AddCommandParserTest {
         // invalid address
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
                 + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Address.MESSAGE_CONSTRAINTS);
+
+        // invalid telegramUsername
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+            + INVALID_TELEGRAM_DESC + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, TelegramUsername.MESSAGE_CONSTRAINTS);
 
         // invalid tag
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB

--- a/src/test/java/tuteez/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/tuteez/logic/parser/AddCommandParserTest.java
@@ -153,6 +153,24 @@ public class AddCommandParserTest {
     }
 
     @Test
+    public void parse_optionalFieldsAddressMissing_success() {
+        Person expectedPerson = new PersonBuilder(AMY).withAddress(null)
+                .withTags(VALID_TAG_FRIEND).build();
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + TELEGRAM_DESC_AMY
+                + TAG_DESC_FRIEND,
+                new AddCommand(expectedPerson));
+    }
+
+    @Test
+    public void parse_optionalFieldsEmailMissing_success() {
+        Person expectedPerson = new PersonBuilder(AMY).withEmail(null)
+                .withTags(VALID_TAG_FRIEND).build();
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + ADDRESS_DESC_AMY + TELEGRAM_DESC_AMY
+                + TAG_DESC_FRIEND,
+                new AddCommand(expectedPerson));
+    }
+
+    @Test
     public void parse_compulsoryFieldMissing_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
 
@@ -162,14 +180,6 @@ public class AddCommandParserTest {
 
         // missing phone prefix
         assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
-
-        // missing email prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + VALID_EMAIL_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
-
-        // missing address prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + VALID_ADDRESS_BOB,
                 expectedMessage);
 
         // all prefixes missing

--- a/src/test/java/tuteez/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/tuteez/logic/parser/EditCommandParserTest.java
@@ -45,7 +45,6 @@ import tuteez.commons.core.index.Index;
 import tuteez.logic.Messages;
 import tuteez.logic.commands.EditCommand;
 import tuteez.logic.commands.EditCommand.EditPersonDescriptor;
-import tuteez.model.person.Address;
 import tuteez.model.person.Email;
 import tuteez.model.person.Name;
 import tuteez.model.person.Phone;

--- a/src/test/java/tuteez/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/tuteez/logic/parser/EditCommandParserTest.java
@@ -5,7 +5,6 @@ import static tuteez.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static tuteez.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static tuteez.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static tuteez.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
-import static tuteez.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
 import static tuteez.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static tuteez.logic.commands.CommandTestUtil.INVALID_LESSON_DESC;
 import static tuteez.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
@@ -63,6 +62,10 @@ public class EditCommandParserTest {
 
     private static final String TELEGRAM_EMPTY = " " + PREFIX_TELEGRAM;
 
+    private static final String EMAIL_EMPTY = " " + PREFIX_EMAIL;
+
+    private static final String ADDRESS_EMPTY = " " + PREFIX_ADDRESS;
+
     private static final String MESSAGE_INVALID_FORMAT =
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
 
@@ -100,7 +103,7 @@ public class EditCommandParserTest {
         assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
         assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
-        assertParseFailure(parser, "1" + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS); // invalid address
+
         assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
         // invalid telegram below
         assertParseFailure(parser, "1" + INVALID_TELEGRAM_DESC, TelegramUsername.MESSAGE_CONSTRAINTS);
@@ -214,7 +217,7 @@ public class EditCommandParserTest {
 
         assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
 
-        // mulltiple valid fields repeated
+        // multiple valid fields repeated
         userInput = targetIndex.getOneBased() + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
                 + TAG_DESC_FRIEND + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
                 + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND + LESSON_DESC_MON
@@ -225,13 +228,12 @@ public class EditCommandParserTest {
                         PREFIX_TELEGRAM));
 
         // multiple invalid values
-        userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC
-                + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC + INVALID_LESSON_DESC
+        userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + INVALID_EMAIL_DESC
+                + INVALID_PHONE_DESC + INVALID_EMAIL_DESC + INVALID_LESSON_DESC
                 + INVALID_TELEGRAM_DESC + INVALID_TELEGRAM_DESC;
 
         assertParseFailure(parser, userInput,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-                        PREFIX_TELEGRAM));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_TELEGRAM));
     }
 
     @Test
@@ -262,6 +264,28 @@ public class EditCommandParserTest {
         String userInput = targetIndex.getOneBased() + TELEGRAM_EMPTY;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withTelegram(null).build();
+        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_deleteEmail_success() {
+        Index targetIndex = INDEX_THIRD_PERSON;
+        String userInput = targetIndex.getOneBased() + EMAIL_EMPTY;
+
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withEmail(null).build();
+        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_deleteAddress_success() {
+        Index targetIndex = INDEX_THIRD_PERSON;
+        String userInput = targetIndex.getOneBased() + ADDRESS_EMPTY;
+
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withAddress(null).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);

--- a/src/test/java/tuteez/logic/parser/ParserUtilTest.java
+++ b/src/test/java/tuteez/logic/parser/ParserUtilTest.java
@@ -113,8 +113,8 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseAddress_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> ParserUtil.parseAddress((String) null));
+    public void parseAddress_null_returnsEmptyAddress() throws ParseException {
+        assertEquals(new Address(null), ParserUtil.parseAddress(null));
     }
 
     @Test
@@ -136,8 +136,8 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseEmail_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> ParserUtil.parseEmail((String) null));
+    public void parseEmail_null_returnsEmptyEmail() throws ParseException {
+        assertEquals(new Email(null), ParserUtil.parseEmail(null));
     }
 
     @Test

--- a/src/test/java/tuteez/logic/parser/ParserUtilTest.java
+++ b/src/test/java/tuteez/logic/parser/ParserUtilTest.java
@@ -18,6 +18,7 @@ import tuteez.model.person.Address;
 import tuteez.model.person.Email;
 import tuteez.model.person.Name;
 import tuteez.model.person.Phone;
+import tuteez.model.person.TelegramUsername;
 import tuteez.model.person.lesson.Lesson;
 import tuteez.model.tag.Tag;
 
@@ -26,6 +27,7 @@ public class ParserUtilTest {
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
+    private static final String INVALID_TELEGRAM = "J@ckson";
     private static final String INVALID_TAG = "#friend";
 
     private static final String INVALID_LESSON = "someday 0900-1100";
@@ -34,6 +36,7 @@ public class ParserUtilTest {
     private static final String VALID_PHONE = "123456";
     private static final String VALID_ADDRESS = "123 Main Street #0505";
     private static final String VALID_EMAIL = "rachel@example.com";
+    private static final String VALID_TELEGRAM = "rachel_walker";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
 
@@ -153,6 +156,27 @@ public class ParserUtilTest {
         String emailWithWhitespace = WHITESPACE + VALID_EMAIL + WHITESPACE;
         Email expectedEmail = new Email(VALID_EMAIL);
         assertEquals(expectedEmail, ParserUtil.parseEmail(emailWithWhitespace));
+    }
+
+    @Test
+    public void parseTelegram_null_returnsEmptyTelegramUsername() throws ParseException {
+        assertEquals(TelegramUsername.empty(), ParserUtil.parseTelegramUsername(null));
+    }
+
+    @Test
+    public void parseTelegram_emptyString_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseTelegramUsername(""));
+    }
+
+    @Test
+    public void parseTelegram_invalidUsername_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseTelegramUsername(INVALID_TELEGRAM));
+    }
+
+    @Test
+    public void parseTelegram_validUsername_returnsTelegramUsername() throws Exception {
+        TelegramUsername expectedTelegramUsername = TelegramUsername.of(VALID_TELEGRAM);
+        assertEquals(expectedTelegramUsername, ParserUtil.parseTelegramUsername(VALID_TELEGRAM));
     }
 
     @Test

--- a/src/test/java/tuteez/model/person/AddressTest.java
+++ b/src/test/java/tuteez/model/person/AddressTest.java
@@ -1,5 +1,6 @@
 package tuteez.model.person;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static tuteez.testutil.Assert.assertThrows;
@@ -9,8 +10,8 @@ import org.junit.jupiter.api.Test;
 public class AddressTest {
 
     @Test
-    public void constructor_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new Address(null));
+    public void constructor_null_returnsAddressWithNullValue() {
+        assertEquals(new Address(null).value, null);
     }
 
     @Test
@@ -21,8 +22,6 @@ public class AddressTest {
 
     @Test
     public void isValidAddress() {
-        // null address
-        assertThrows(NullPointerException.class, () -> Address.isValidAddress(null));
 
         // invalid addresses
         assertFalse(Address.isValidAddress("")); // empty string
@@ -37,6 +36,7 @@ public class AddressTest {
     @Test
     public void equals() {
         Address address = new Address("Valid Address");
+        Address emptyAddress = new Address(null);
 
         // same values -> returns true
         assertTrue(address.equals(new Address("Valid Address")));
@@ -52,5 +52,8 @@ public class AddressTest {
 
         // different values -> returns false
         assertFalse(address.equals(new Address("Other Valid Address")));
+
+        // empty address -> equals address with null value
+        assertTrue(emptyAddress.equals(new Address(null)));
     }
 }

--- a/src/test/java/tuteez/model/person/AddressTest.java
+++ b/src/test/java/tuteez/model/person/AddressTest.java
@@ -22,6 +22,8 @@ public class AddressTest {
 
     @Test
     public void isValidAddress() {
+        // null address
+        assertTrue(Address.isValidAddress(null));
 
         // invalid addresses
         assertFalse(Address.isValidAddress("")); // empty string
@@ -55,5 +57,23 @@ public class AddressTest {
 
         // empty address -> equals address with null value
         assertTrue(emptyAddress.equals(new Address(null)));
+    }
+
+    @Test
+    public void toString_validAddress_returnsAddressString() {
+        Address address = new Address("Valid Address");
+        assertEquals(address.toString(), "Valid Address");
+    }
+
+    @Test
+    public void toString_emptyAddress_returnsEmptyString() {
+        Address emptyAddress = new Address(null);
+        assertEquals(emptyAddress.toString(), "");
+    }
+
+    @Test
+    public void hashCode_emptyAddress_returnsZero() {
+        Address emptyAddress = new Address(null);
+        assertEquals(emptyAddress.hashCode(), 0);
     }
 }

--- a/src/test/java/tuteez/model/person/AddressTest.java
+++ b/src/test/java/tuteez/model/person/AddressTest.java
@@ -39,6 +39,7 @@ public class AddressTest {
     public void equals() {
         Address address = new Address("Valid Address");
         Address emptyAddress = new Address(null);
+        Address emptyAddress2 = new Address(null);
 
         // same values -> returns true
         assertTrue(address.equals(new Address("Valid Address")));
@@ -57,6 +58,8 @@ public class AddressTest {
 
         // empty address -> equals address with null value
         assertTrue(emptyAddress.equals(new Address(null)));
+
+        assertTrue(emptyAddress.equals(emptyAddress2));
     }
 
     @Test

--- a/src/test/java/tuteez/model/person/EmailTest.java
+++ b/src/test/java/tuteez/model/person/EmailTest.java
@@ -22,6 +22,8 @@ public class EmailTest {
 
     @Test
     public void isValidEmail() {
+        // null email
+        assertTrue(Email.isValidEmail(null));
 
         // blank email
         assertFalse(Email.isValidEmail("")); // empty string
@@ -88,4 +90,23 @@ public class EmailTest {
         // empty email -> equals email with null value
         assertTrue(emptyEmail.equals(new Email(null)));
     }
+
+    @Test
+    public void toString_validEmail_returnsEmailString() {
+        Email email = new Email("valid@email");
+        assertEquals(email.toString(), "valid@email");
+    }
+
+    @Test
+    public void toString_emptyEmail_returnsEmptyString() {
+        Email emptyEmail = new Email(null);
+        assertEquals(emptyEmail.toString(), "");
+    }
+
+    @Test
+    public void hashCode_emptyEmail_returnsZero() {
+        Email emptyEmail = new Email(null);
+        assertEquals(emptyEmail.hashCode(), 0);
+    }
+
 }

--- a/src/test/java/tuteez/model/person/EmailTest.java
+++ b/src/test/java/tuteez/model/person/EmailTest.java
@@ -1,5 +1,6 @@
 package tuteez.model.person;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static tuteez.testutil.Assert.assertThrows;
@@ -10,7 +11,7 @@ public class EmailTest {
 
     @Test
     public void constructor_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new Email(null));
+        assertEquals(new Email(null).value, null);
     }
 
     @Test
@@ -21,8 +22,6 @@ public class EmailTest {
 
     @Test
     public void isValidEmail() {
-        // null email
-        assertThrows(NullPointerException.class, () -> Email.isValidEmail(null));
 
         // blank email
         assertFalse(Email.isValidEmail("")); // empty string
@@ -69,6 +68,7 @@ public class EmailTest {
     @Test
     public void equals() {
         Email email = new Email("valid@email");
+        Email emptyEmail = new Email(null);
 
         // same values -> returns true
         assertTrue(email.equals(new Email("valid@email")));
@@ -84,5 +84,8 @@ public class EmailTest {
 
         // different values -> returns false
         assertFalse(email.equals(new Email("other.valid@email")));
+
+        // empty email -> equals email with null value
+        assertTrue(emptyEmail.equals(new Email(null)));
     }
 }

--- a/src/test/java/tuteez/model/person/EmailTest.java
+++ b/src/test/java/tuteez/model/person/EmailTest.java
@@ -71,6 +71,7 @@ public class EmailTest {
     public void equals() {
         Email email = new Email("valid@email");
         Email emptyEmail = new Email(null);
+        Email emptyEmail2 = new Email(null);
 
         // same values -> returns true
         assertTrue(email.equals(new Email("valid@email")));
@@ -89,6 +90,8 @@ public class EmailTest {
 
         // empty email -> equals email with null value
         assertTrue(emptyEmail.equals(new Email(null)));
+
+        assertTrue(emptyEmail.equals(emptyEmail2));
     }
 
     @Test

--- a/src/test/java/tuteez/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/tuteez/storage/JsonAdaptedPersonTest.java
@@ -89,13 +89,6 @@ public class JsonAdaptedPersonTest {
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
-    @Test
-    public void toModelType_nullEmail_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS,
-                VALID_TELEGRAM, VALID_TAGS, VALID_LESSONS, VALID_REMARKLIST);
-        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
-        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
-    }
 
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
@@ -103,14 +96,6 @@ public class JsonAdaptedPersonTest {
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS,
                         VALID_TELEGRAM, VALID_TAGS, VALID_LESSONS, VALID_REMARKLIST);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
-        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
-    }
-
-    @Test
-    public void toModelType_nullAddress_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null,
-                VALID_TELEGRAM, VALID_TAGS, VALID_LESSONS, VALID_REMARKLIST);
-        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 


### PR DESCRIPTION
-Fixes #82 

### What is this Pull Request for?
Currently, address and email fields are compulsory fields when adding a student's contact. However, in real life, tutors may not know the student's email, since we rarely communicate over emails in informal settings, and tutors may not need to know the student's address as it could be an online tuition lesson. 

However, emails and addresses cannot be blank when choosing to add them through an `add` command, but can be blank when editing them through an `edit` command to delete the emails and addresses. 

### What does this pull request do?
- Update Address and Email classes to take in optional values
- Update AddCommand and EditCommand parsers to handle optional emails and addresses
- Update Email, Address, and Telegram Usernames to be able to be deleted through edit command. 
- Update the UI to hide emails and addresses when they are not added.
- Update the respective test cases

### Important Notes
- Emails, Addresses, and Telegram Usernames can be deleted through edit command by specifying their respective commands with empty whitespaces. However, whitespaces cannot be used as input for add command.