### PR TITLE
Add remarklist in edit command

### DIFF
--- a/src/main/java/tuteez/logic/commands/EditCommand.java
+++ b/src/main/java/tuteez/logic/commands/EditCommand.java
@@ -33,6 +33,7 @@ import tuteez.model.person.Person;
 import tuteez.model.person.Phone;
 import tuteez.model.person.TelegramUsername;
 import tuteez.model.person.lesson.Lesson;
+import tuteez.model.remark.RemarkList;
 import tuteez.model.tag.Tag;
 
 /**
@@ -136,9 +137,10 @@ public class EditCommand extends Command {
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
         Set<Lesson> updatedLessons = editPersonDescriptor.getLessons().orElse(personToEdit.getLessons());
 
+        RemarkList originalRemarkList = personToEdit.getRemarkList();
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTelegramUser, updatedTags,
-                updatedLessons);
+                updatedLessons, originalRemarkList);
     }
 
     @Override


### PR DESCRIPTION
Fixes #124 
- When the `edit` command is called, the selected person's remarks remain. 

Note: `remark` cannot be edited by the `edit` command, and this is intended in the design of our commands (perhaps this can be discussed again together with `lesson`)