### PR TITLE
Make error messages more specific for `remark` command

### DIFF
--- a/src/main/java/tuteez/logic/Messages.java
+++ b/src/main/java/tuteez/logic/Messages.java
@@ -14,10 +14,27 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
+
+    public static final String MESSAGE_EMPTY_REMARK =
+            "Remark cannot be empty. Please provide type out the remark.";
+    public static final String MESSAGE_MISSING_PERSON_INDEX =
+            "Person index is required but missing. Please provide the index of the person as displayed in the list.";
+    public static final String MESSAGE_INVALID_PERSON_INDEX_FORMAT =
+            "Person index must be a single, positive number (eg, '1', '2', '3').";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+
+    public static final String MESSAGE_REMARK_MULTIPLE_OPERATIONS =
+            "Cannot add and delete remarks simultaneously. Please use only one operation at a time.";
+    public static final String MESSAGE_REMARK_MISSING_COMMAND_TYPE =
+            "Please specify whether to add or delete a remark using '-a' or '-d'.";
+    public static final String MESSAGE_MISSING_REMARK_INDEX = "Remark index is required for deletion but missing. "
+            + "Please specify which remark to delete (e.g., 'remark 1 -d 1').";
+    public static final String MESSAGE_INVALID_REMARK_INDEX_FORMAT =
+            "Remark index must be a single, positive number (e.g., '1', '2', '3').";
     public static final String MESSAGE_INVALID_REMARK_INDEX = "The remark index provided is invalid";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_NAME =
                 "No student named %1$s was found, please try again!";
+
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";

--- a/src/main/java/tuteez/logic/Messages.java
+++ b/src/main/java/tuteez/logic/Messages.java
@@ -16,7 +16,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
 
     public static final String MESSAGE_EMPTY_REMARK =
-            "Remark cannot be empty. Please provide type out the remark.";
+            "Remark cannot be empty. Please provide a remark.";
     public static final String MESSAGE_MISSING_PERSON_INDEX =
             "Person index is required but missing. Please provide the index of the person as displayed in the list.";
     public static final String MESSAGE_INVALID_PERSON_INDEX_FORMAT =

--- a/src/main/java/tuteez/logic/Messages.java
+++ b/src/main/java/tuteez/logic/Messages.java
@@ -15,8 +15,6 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
 
-    public static final String MESSAGE_EMPTY_REMARK =
-            "Remark cannot be empty. Please provide a remark.";
     public static final String MESSAGE_MISSING_PERSON_INDEX =
             "Person index is required but missing. Please provide the index of the person as displayed in the list.";
     public static final String MESSAGE_INVALID_PERSON_INDEX_FORMAT =

--- a/src/main/java/tuteez/logic/parser/ParserUtil.java
+++ b/src/main/java/tuteez/logic/parser/ParserUtil.java
@@ -177,10 +177,10 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String email} into an {@code Email}.
+     * Parses a {@code String remark} into an {@code Remark}.
      * Leading and trailing whitespaces will be trimmed.
      *
-     * @throws ParseException if the given {@code email} is invalid.
+     * @throws ParseException if the given {@code remark} is invalid.
      */
     public static Remark parseRemark(String remark) throws ParseException {
         requireNonNull(remark);

--- a/src/main/java/tuteez/logic/parser/ParserUtil.java
+++ b/src/main/java/tuteez/logic/parser/ParserUtil.java
@@ -15,6 +15,7 @@ import tuteez.model.person.Name;
 import tuteez.model.person.Phone;
 import tuteez.model.person.TelegramUsername;
 import tuteez.model.person.lesson.Lesson;
+import tuteez.model.remark.Remark;
 import tuteez.model.tag.Tag;
 
 /**
@@ -173,5 +174,20 @@ public class ParserUtil {
             lessonSet.add(parseLesson(lesson));
         }
         return lessonSet;
+    }
+
+    /**
+     * Parses a {@code String email} into an {@code Email}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code email} is invalid.
+     */
+    public static Remark parseRemark(String remark) throws ParseException {
+        requireNonNull(remark);
+        String trimmedRemark = remark.trim();
+        if (!Remark.isValidRemark(trimmedRemark)) {
+            throw new ParseException(Remark.MESSAGE_CONSTRAINTS);
+        }
+        return new Remark(trimmedRemark);
     }
 }

--- a/src/main/java/tuteez/logic/parser/RemarkCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/RemarkCommandParser.java
@@ -1,6 +1,14 @@
 package tuteez.logic.parser;
 
+import static java.util.Objects.requireNonNull;
+import static tuteez.logic.Messages.MESSAGE_EMPTY_REMARK;
 import static tuteez.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static tuteez.logic.Messages.MESSAGE_INVALID_PERSON_INDEX_FORMAT;
+import static tuteez.logic.Messages.MESSAGE_INVALID_REMARK_INDEX_FORMAT;
+import static tuteez.logic.Messages.MESSAGE_MISSING_PERSON_INDEX;
+import static tuteez.logic.Messages.MESSAGE_MISSING_REMARK_INDEX;
+import static tuteez.logic.Messages.MESSAGE_REMARK_MISSING_COMMAND_TYPE;
+import static tuteez.logic.Messages.MESSAGE_REMARK_MULTIPLE_OPERATIONS;
 import static tuteez.logic.parser.CliSyntax.PREFIX_ADD_REMARK;
 import static tuteez.logic.parser.CliSyntax.PREFIX_DELETE_REMARK;
 
@@ -19,29 +27,109 @@ public class RemarkCommandParser implements Parser<RemarkCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the RemarkCommand
      * and returns a RemarkCommand object for execution.
-     *
      * @throws ParseException if the user input does not conform the expected format
      */
     public RemarkCommand parse(String args) throws ParseException {
+        requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_ADD_REMARK, PREFIX_DELETE_REMARK);
 
-        Index personIndex;
+        validateBasicCommandFormat(args);
+        validateOperationType(argMultimap);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_ADD_REMARK, PREFIX_DELETE_REMARK);
+
+        Index personIndex = parsePersonIndex(argMultimap);
+
+        if (isAddRemarkCommand(argMultimap)) {
+            return createAddRemarkCommand(personIndex, argMultimap);
+        }
+
+        if (isDeleteRemarkCommand(argMultimap)) {
+            return createDeleteRemarkCommand(personIndex, argMultimap);
+        }
+
+        throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_REMARK_MISSING_COMMAND_TYPE));
+    }
+
+    private void validateBasicCommandFormat(String args) throws ParseException {
+        if (args.trim().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemarkCommand.MESSAGE_USAGE));
+        }
+    }
+
+    private void validateOperationType(ArgumentMultimap argMultimap) throws ParseException {
+        boolean hasAddPrefix = argMultimap.getValue(PREFIX_ADD_REMARK).isPresent();
+        boolean hasDeletePrefix = argMultimap.getValue(PREFIX_DELETE_REMARK).isPresent();
+
+        if (hasAddPrefix && hasDeletePrefix) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    MESSAGE_REMARK_MULTIPLE_OPERATIONS));
+        }
+
+        if (!hasAddPrefix && !hasDeletePrefix) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    MESSAGE_REMARK_MISSING_COMMAND_TYPE));
+        }
+    }
+
+    private Index parsePersonIndex(ArgumentMultimap argMultimap) throws ParseException {
+        String preamble = argMultimap.getPreamble().trim();
+
+        if (preamble.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_PERSON_INDEX));
+        }
+
+        Index index;
+
         try {
-            personIndex = ParserUtil.parseIndex(argMultimap.getPreamble());
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemarkCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    MESSAGE_INVALID_PERSON_INDEX_FORMAT));
+        }
+        return index;
+    }
+
+    private AddRemarkCommand createAddRemarkCommand(Index personIndex, ArgumentMultimap argMultimap)
+            throws ParseException {
+
+        assert argMultimap.getValue(PREFIX_ADD_REMARK).isPresent();
+
+        String remarkString = argMultimap.getValue(PREFIX_ADD_REMARK).get();
+
+        if (remarkString.trim().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_EMPTY_REMARK));
         }
 
-        if (argMultimap.getValue(PREFIX_ADD_REMARK).isPresent()) {
-            String remarkString = argMultimap.getValue(PREFIX_ADD_REMARK).get();
-            return new AddRemarkCommand(personIndex, new Remark(remarkString));
+        return new AddRemarkCommand(personIndex, new Remark(remarkString));
+    }
+
+    private DeleteRemarkCommand createDeleteRemarkCommand(Index personIndex, ArgumentMultimap argMultimap)
+            throws ParseException {
+
+        assert argMultimap.getValue(PREFIX_DELETE_REMARK).isPresent();
+
+        String remarkIndexStr = argMultimap.getValue(PREFIX_DELETE_REMARK).get();
+
+        if (remarkIndexStr.trim().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_REMARK_INDEX));
         }
 
-        if (argMultimap.getValue(PREFIX_DELETE_REMARK).isPresent()) {
-            Index remarkIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_DELETE_REMARK).get());
-            return new DeleteRemarkCommand(personIndex, remarkIndex);
-        }
+        Index index;
 
-        throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemarkCommand.MESSAGE_USAGE));
+        try {
+            index = ParserUtil.parseIndex(remarkIndexStr);
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    MESSAGE_INVALID_REMARK_INDEX_FORMAT));
+        }
+        return new DeleteRemarkCommand(personIndex, index);
+    }
+
+    private boolean isAddRemarkCommand(ArgumentMultimap argMultimap) {
+        return argMultimap.getValue(PREFIX_ADD_REMARK).isPresent();
+    }
+
+    private boolean isDeleteRemarkCommand(ArgumentMultimap argMultimap) {
+        return argMultimap.getValue(PREFIX_DELETE_REMARK).isPresent();
     }
 }

--- a/src/main/java/tuteez/logic/parser/RemarkCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/RemarkCommandParser.java
@@ -1,7 +1,6 @@
 package tuteez.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static tuteez.logic.Messages.MESSAGE_EMPTY_REMARK;
 import static tuteez.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static tuteez.logic.Messages.MESSAGE_INVALID_PERSON_INDEX_FORMAT;
 import static tuteez.logic.Messages.MESSAGE_INVALID_REMARK_INDEX_FORMAT;
@@ -96,11 +95,9 @@ public class RemarkCommandParser implements Parser<RemarkCommand> {
 
         String remarkString = argMultimap.getValue(PREFIX_ADD_REMARK).get();
 
-        if (remarkString.trim().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_EMPTY_REMARK));
-        }
+        Remark remark = ParserUtil.parseRemark(remarkString);
 
-        return new AddRemarkCommand(personIndex, new Remark(remarkString));
+        return new AddRemarkCommand(personIndex, remark);
     }
 
     private DeleteRemarkCommand createDeleteRemarkCommand(Index personIndex, ArgumentMultimap argMultimap)

--- a/src/test/java/tuteez/logic/parser/ParserUtilTest.java
+++ b/src/test/java/tuteez/logic/parser/ParserUtilTest.java
@@ -20,6 +20,7 @@ import tuteez.model.person.Name;
 import tuteez.model.person.Phone;
 import tuteez.model.person.TelegramUsername;
 import tuteez.model.person.lesson.Lesson;
+import tuteez.model.remark.Remark;
 import tuteez.model.tag.Tag;
 
 public class ParserUtilTest {
@@ -29,8 +30,8 @@ public class ParserUtilTest {
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TELEGRAM = "J@ckson";
     private static final String INVALID_TAG = "#friend";
-
     private static final String INVALID_LESSON = "someday 0900-1100";
+    private static final String INVALID_REMARK = " ";
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
@@ -39,10 +40,9 @@ public class ParserUtilTest {
     private static final String VALID_TELEGRAM = "rachel_walker";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
-
     private static final String VALID_LESSON = "monday 0800-1100";
-
     private static final String VALID_LESSON_2 = "sunday 0900-1135";
+    private static final String VALID_REMARK = "Good progress!";
 
     private static final String WHITESPACE = " \t\r\n";
 
@@ -266,5 +266,28 @@ public class ParserUtilTest {
                 new HashSet<>(Arrays.asList(new Lesson(VALID_LESSON), new Lesson(VALID_LESSON_2)));
 
         assertEquals(actualLessonSet, expectedLessonSet);
+    }
+
+    @Test
+    public void parseRemark_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseRemark((String) null));
+    }
+
+    @Test
+    public void parseRemark_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseRemark(INVALID_REMARK));
+    }
+
+    @Test
+    public void parseRemark_validValueWithoutWhitespace_returnsPhone() throws Exception {
+        Remark expectedRemark = new Remark(VALID_REMARK);
+        assertEquals(expectedRemark, ParserUtil.parseRemark(VALID_REMARK));
+    }
+
+    @Test
+    public void parseRemark_validValueWithWhitespace_returnsTrimmedPhone() throws Exception {
+        String remarkWithWhitespace = WHITESPACE + VALID_REMARK + WHITESPACE;
+        Remark expectedRemark = new Remark(VALID_REMARK);
+        assertEquals(expectedRemark, ParserUtil.parseRemark(remarkWithWhitespace));
     }
 }

--- a/src/test/java/tuteez/logic/parser/RemarkCommandParserTest.java
+++ b/src/test/java/tuteez/logic/parser/RemarkCommandParserTest.java
@@ -1,6 +1,5 @@
 package tuteez.logic.parser;
 
-import static tuteez.logic.Messages.MESSAGE_EMPTY_REMARK;
 import static tuteez.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static tuteez.logic.Messages.MESSAGE_INVALID_PERSON_INDEX_FORMAT;
 import static tuteez.logic.Messages.MESSAGE_INVALID_REMARK_INDEX_FORMAT;
@@ -92,10 +91,10 @@ public class RemarkCommandParserTest {
     @Test
     public void parse_emptyRemarkContent_throwsParseException() {
         assertParseFailure(parser, "1 " + AddRemarkCommand.ADD_REMARK_PARAM + "",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_EMPTY_REMARK));
+                Remark.MESSAGE_CONSTRAINTS);
 
         assertParseFailure(parser, "1 " + AddRemarkCommand.ADD_REMARK_PARAM + " ",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_EMPTY_REMARK));
+                Remark.MESSAGE_CONSTRAINTS);
     }
 
     @Test

--- a/src/test/java/tuteez/logic/parser/RemarkCommandParserTest.java
+++ b/src/test/java/tuteez/logic/parser/RemarkCommandParserTest.java
@@ -83,9 +83,9 @@ public class RemarkCommandParserTest {
 
     @Test
     public void parse_noPersonIndexSpecified_throwsParseException() {
-        assertParseFailure(parser, AddRemarkCommand.ADD_REMARK_PARAM + " Some remark",
+        assertParseFailure(parser, String.format(" %s Some remark", AddRemarkCommand.ADD_REMARK_PARAM),
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_PERSON_INDEX));
-        assertParseFailure(parser, DeleteRemarkCommand.DELETE_REMARK_PARAM + " 1",
+        assertParseFailure(parser, String.format(" %s 1", DeleteRemarkCommand.DELETE_REMARK_PARAM),
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_PERSON_INDEX));
     }
 

--- a/src/test/java/tuteez/logic/parser/RemarkCommandParserTest.java
+++ b/src/test/java/tuteez/logic/parser/RemarkCommandParserTest.java
@@ -1,6 +1,13 @@
 package tuteez.logic.parser;
 
+import static tuteez.logic.Messages.MESSAGE_EMPTY_REMARK;
 import static tuteez.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static tuteez.logic.Messages.MESSAGE_INVALID_PERSON_INDEX_FORMAT;
+import static tuteez.logic.Messages.MESSAGE_INVALID_REMARK_INDEX_FORMAT;
+import static tuteez.logic.Messages.MESSAGE_MISSING_PERSON_INDEX;
+import static tuteez.logic.Messages.MESSAGE_MISSING_REMARK_INDEX;
+import static tuteez.logic.Messages.MESSAGE_REMARK_MISSING_COMMAND_TYPE;
+import static tuteez.logic.Messages.MESSAGE_REMARK_MULTIPLE_OPERATIONS;
 import static tuteez.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static tuteez.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static tuteez.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -32,27 +39,80 @@ public class RemarkCommandParserTest {
     }
 
     @Test
-    public void parse_invalidRemarkType_throwsParseException() {
-        assertParseFailure(parser, "1 -x Some remark",
+    public void parse_whitespaceOnlyAfterCommandWord_throwsParseException() {
+        assertParseFailure(parser, " ",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemarkCommand.MESSAGE_USAGE));
     }
 
     @Test
-    public void parse_invalidIndex_throwsParseException() {
+    public void parse_multipleCommandTypes_throwsParseException() {
+        assertParseFailure(parser,
+                String.format("1 %s Some remark %s 2", AddRemarkCommand.ADD_REMARK_PARAM,
+                        DeleteRemarkCommand.DELETE_REMARK_PARAM),
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_REMARK_MULTIPLE_OPERATIONS));
+    }
+
+    @Test
+    public void parse_invalidCommandType_throwsParseException() {
+        assertParseFailure(parser, "1 -x Some remark",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_REMARK_MISSING_COMMAND_TYPE));
+
+        assertParseFailure(parser, "1 a/ Some remark",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_REMARK_MISSING_COMMAND_TYPE));
+    }
+
+    @Test
+    public void parse_missingCommandType_throwsParseException() {
+        assertParseFailure(parser, "1 Some remark",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_REMARK_MISSING_COMMAND_TYPE));
+
+        assertParseFailure(parser, "1 2",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_REMARK_MISSING_COMMAND_TYPE));
+    }
+
+    @Test
+    public void parse_invalidPersonIndex_throwsParseException() {
         // Invalid index for add remark
-        assertParseFailure(parser, "-1 " + AddRemarkCommand.ADD_REMARK_PARAM + " Some remark",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemarkCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "0 " + AddRemarkCommand.ADD_REMARK_PARAM + " Some remark",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_INVALID_PERSON_INDEX_FORMAT));
 
         // Invalid index for delete remark
-        assertParseFailure(parser, "-1 " + DeleteRemarkCommand.DELETE_REMARK_PARAM + " 1 1",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemarkCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "-1 " + DeleteRemarkCommand.DELETE_REMARK_PARAM + " 1",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_INVALID_PERSON_INDEX_FORMAT));
     }
 
     @Test
     public void parse_noPersonIndexSpecified_throwsParseException() {
         assertParseFailure(parser, AddRemarkCommand.ADD_REMARK_PARAM + " Some remark",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemarkCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_PERSON_INDEX));
         assertParseFailure(parser, DeleteRemarkCommand.DELETE_REMARK_PARAM + " 1",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemarkCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_PERSON_INDEX));
+    }
+
+    @Test
+    public void parse_emptyRemarkContent_throwsParseException() {
+        assertParseFailure(parser, "1 " + AddRemarkCommand.ADD_REMARK_PARAM + "",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_EMPTY_REMARK));
+
+        assertParseFailure(parser, "1 " + AddRemarkCommand.ADD_REMARK_PARAM + " ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_EMPTY_REMARK));
+    }
+
+    @Test
+    public void parse_missingRemarkIndex_throwsParseException() {
+        assertParseFailure(parser, String.format("1 %s", DeleteRemarkCommand.DELETE_REMARK_PARAM),
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_REMARK_INDEX));
+
+        assertParseFailure(parser, String.format("1 %s ", DeleteRemarkCommand.DELETE_REMARK_PARAM),
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_REMARK_INDEX));
+    }
+
+    @Test
+    public void parse_invalidRemarkIndex_throwsParseException() {
+        assertParseFailure(parser, String.format("1 %s 0", DeleteRemarkCommand.DELETE_REMARK_PARAM),
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_INVALID_REMARK_INDEX_FORMAT));
+
+        assertParseFailure(parser, String.format("1 %s -1", DeleteRemarkCommand.DELETE_REMARK_PARAM),
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_INVALID_REMARK_INDEX_FORMAT));
     }
 }


### PR DESCRIPTION
Fixes #130 

## What is this PR for?
Previously, the error messages of the `remark` command lacked specificity, so users may have trouble identifying which part of their command is wrong. This PR identifies the error of their input and lets them know, enhancing user experience.

## What does this PR do?
Outputs more specific error messages for the `remark` command.