### PR TITLE
Enhance clash detection to provide detailed information on conflicts

### DIFF
--- a/src/main/java/tuteez/logic/commands/AddCommand.java
+++ b/src/main/java/tuteez/logic/commands/AddCommand.java
@@ -9,6 +9,9 @@ import static tuteez.logic.parser.CliSyntax.PREFIX_PHONE;
 import static tuteez.logic.parser.CliSyntax.PREFIX_TAG;
 import static tuteez.logic.parser.CliSyntax.PREFIX_TELEGRAM;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -51,8 +54,7 @@ public class AddCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New student added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This student already exists in the address book";
-    public static final String MESSAGE_DUPLICATE_LESSON = "This time slot is already taken by another "
-            + " student, please retype command";
+    public static final String MESSAGE_CLASHING_LESSON = "This time slot is clashes with the following lessons: \n";
 
     private final Person toAdd;
     private final Logger logger = LogsCenter.getLogger(AddCommand.class);
@@ -74,14 +76,30 @@ public class AddCommand extends Command {
         }
 
         Set<Lesson> lessonSet = toAdd.getLessons();
+        Map<Person, ArrayList<Lesson>> resultMap = new HashMap<>();
         for (Lesson lesson: lessonSet) {
             assert lesson != null;
-            if (model.isClashingWithExistingLesson(lesson)) {
-                String logMessage = String.format("Student: %s | Lessons: %s | Conflict: Clashes with "
-                        + "another student's lesson", toAdd.getName(), toAdd.getLessons().toString());
-                logger.info(logMessage);
-                throw new CommandException(MESSAGE_DUPLICATE_LESSON);
-            }
+            Map<Person, ArrayList<Lesson>> clashingLessons = model.getClashingLessons(lesson);
+
+            clashingLessons.forEach((person, lessons) -> {
+                assert !person.equals(toAdd) : "By this point a duplicate person should be flagged out";
+                resultMap.computeIfAbsent(person, k -> new ArrayList<>()).addAll(lessons);
+            });
+        }
+
+        if (!resultMap.isEmpty()) {
+            String logMessage = String.format("Student: %s | Lessons: %s | Conflict: Clashes with "
+                    + "another student's lesson", toAdd.getName(), toAdd.getLessons().toString());
+            logger.info(logMessage);
+
+            StringBuilder sb = new StringBuilder(MESSAGE_CLASHING_LESSON).append("\n");
+            resultMap.keySet().forEach(student -> {
+                sb.append(student.getName()).append(": ");
+
+                resultMap.get(student).forEach(ls -> sb.append(ls.getDayAndTime()).append(" "));
+                sb.append("\n");
+            });
+            throw new CommandException(sb.toString());
         }
 
         model.addPerson(toAdd);

--- a/src/main/java/tuteez/logic/parser/ParserUtil.java
+++ b/src/main/java/tuteez/logic/parser/ParserUtil.java
@@ -12,6 +12,7 @@ import tuteez.logic.parser.exceptions.ParseException;
 import tuteez.model.person.Address;
 import tuteez.model.person.Email;
 import tuteez.model.person.Name;
+import tuteez.model.person.Person;
 import tuteez.model.person.Phone;
 import tuteez.model.person.TelegramUsername;
 import tuteez.model.person.lesson.Lesson;

--- a/src/main/java/tuteez/model/AddressBook.java
+++ b/src/main/java/tuteez/model/AddressBook.java
@@ -2,7 +2,9 @@ package tuteez.model;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import javafx.collections.ObservableList;
 import tuteez.commons.util.ToStringBuilder;
@@ -129,8 +131,8 @@ public class AddressBook implements ReadOnlyAddressBook {
                 .orElse(null);
     }
 
-    public boolean isClashingWithExistingLesson(Lesson lesson) {
-        return lessonManager.isClashingWithExistingLesson(lesson);
+    public Map<Person, ArrayList<Lesson>> getClashingLessons(Lesson lesson) {
+        return lessonManager.getClashingLessons(persons, lesson);
     }
 
     //// util methods

--- a/src/main/java/tuteez/model/Model.java
+++ b/src/main/java/tuteez/model/Model.java
@@ -1,6 +1,8 @@
 package tuteez.model;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -86,7 +88,7 @@ public interface Model {
      */
     void setPerson(Person target, Person editedPerson);
 
-    boolean isClashingWithExistingLesson(Lesson lesson);
+    Map<Person, ArrayList<Lesson>> getClashingLessons(Lesson lesson);
 
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();

--- a/src/main/java/tuteez/model/ModelManager.java
+++ b/src/main/java/tuteez/model/ModelManager.java
@@ -4,6 +4,8 @@ import static java.util.Objects.requireNonNull;
 import static tuteez.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
@@ -131,8 +133,8 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public boolean isClashingWithExistingLesson(Lesson lesson) {
-        return addressBook.isClashingWithExistingLesson(lesson);
+    public Map<Person, ArrayList<Lesson>> getClashingLessons(Lesson lesson) {
+        return addressBook.getClashingLessons(lesson);
     }
 
     //=========== Filtered Person List Accessors =============================================================

--- a/src/main/java/tuteez/model/person/Person.java
+++ b/src/main/java/tuteez/model/person/Person.java
@@ -2,6 +2,7 @@ package tuteez.model.person;
 
 import static tuteez.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
@@ -105,6 +106,16 @@ public class Person {
         return Collections.unmodifiableSet(lessons);
     }
 
+    public ArrayList<Lesson> getLessonsThatClash(Lesson otherLesson) {
+        ArrayList<Lesson> clashedLessons = new ArrayList<>();
+        for (Lesson lesson: lessons) {
+            if (Lesson.isClashingWithOtherLesson(lesson, otherLesson)) {
+                clashedLessons.add(lesson);
+            }
+        }
+        return  clashedLessons;
+    }
+
     /**
      * Returns true if both persons have the same name.
      * This defines a weaker notion of equality between two persons.
@@ -125,6 +136,10 @@ public class Person {
      */
     public boolean isLessonScheduled(Lesson lesson) {
         return lessons.contains(lesson);
+    }
+
+    public boolean hasSameName(Person otherStudent) {
+        return this.name.equals(otherStudent.name);
     }
 
     /**

--- a/src/main/java/tuteez/model/person/lesson/Lesson.java
+++ b/src/main/java/tuteez/model/person/lesson/Lesson.java
@@ -2,6 +2,7 @@ package tuteez.model.person.lesson;
 import static java.util.Objects.requireNonNull;
 import static tuteez.commons.util.AppUtil.checkArgument;
 import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON;
+import tuteez.model.person.Person;
 
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
@@ -29,7 +30,6 @@ public class Lesson {
     private final Day lessonDay;
     private final LocalTime startTime;
     private final LocalTime endTime;
-
 
     /**
      * Constructs a {@code Lesson}.

--- a/src/main/java/tuteez/model/person/lesson/LessonManager.java
+++ b/src/main/java/tuteez/model/person/lesson/LessonManager.java
@@ -1,11 +1,16 @@
 package tuteez.model.person.lesson;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.TreeSet;
 import java.util.logging.Logger;
 
 import tuteez.commons.core.LogsCenter;
 import tuteez.logic.commands.AddCommand;
+import tuteez.model.person.Person;
+import tuteez.model.person.UniquePersonList;
 
 /**
  * A container for all Lesson instances
@@ -63,18 +68,29 @@ public class LessonManager {
      * @return {@code true} if the lesson clashes with any existing lessons on the same day,
      *         {@code false} otherwise.
      */
-    public boolean isClashingWithExistingLesson(Lesson lesson) {
-        Day lessonDay = lesson.getLessonDay();
-        TreeSet<Lesson> lessonsOnDay = dayLessonsMap.get(lessonDay);
-        for (Lesson lessonOnDay : lessonsOnDay) {
-            assert lessonOnDay != null;
-            if (Lesson.isClashingWithOtherLesson(lessonOnDay, lesson)) {
-                String logMessage = String.format("%s clashes with %s", lessonOnDay, lesson);
-                logger.info(logMessage);
-                return true;
+    public Map<Person, ArrayList<Lesson>> getClashingLessons(UniquePersonList studentList, Lesson lesson) {
+//        ArrayList<Lesson> clashingLessonArr = new ArrayList<>();
+//        Day lessonDay = lesson.getLessonDay();
+//        TreeSet<Lesson> lessonsOnDay = dayLessonsMap.get(lessonDay);
+//        for (Lesson lessonOnDay : lessonsOnDay) {
+//            assert lessonOnDay != null;
+//            if (Lesson.isClashingWithOtherLesson(lessonOnDay, lesson)) {
+//                String logMessage = String.format("%s clashes with %s", lessonOnDay, lesson);
+//                logger.info(logMessage);
+//                clashingLessonArr.add(lessonOnDay);
+//            }
+//        }
+//        return clashingLessonArr;
+        Map<Person, ArrayList<Lesson>> clashingLessonMap = new HashMap<>();
+        Iterator<Person> students = studentList.iterator();
+        while (students.hasNext()) {
+            Person stu = students.next();
+            ArrayList<Lesson> clashedLessons = stu.getLessonsThatClash(lesson);
+            if (!clashedLessons.isEmpty()) {
+                clashingLessonMap.put(stu, clashedLessons);
             }
         }
-        return false;
+        return clashingLessonMap;
     }
 
     /**


### PR DESCRIPTION
>[!IMPORTANT]
> Do not merge this into master yet. Unit test and thorough developer testing has not been done yet. This is to provide a base for others to work on


## What is this PR for?
- In `v1.4` system would notify users when a new lesson conflicts with one that already exists. 

## What does this PR do? 
- Provides additional information such as name of student, and exact lesson information of existing lessons that clash with new lesson
- Gives tutors more information to be able to potentially move lessons or deconflict schedules. 
- Improves user experience by making it easier to resolve scheduling conflicts through clearer information on the source of each clash.