### PR TITLE
Make remark commands update displayed person

### DIFF
--- a/src/main/java/tuteez/logic/commands/AddRemarkCommand.java
+++ b/src/main/java/tuteez/logic/commands/AddRemarkCommand.java
@@ -1,6 +1,7 @@
 package tuteez.logic.commands;
 
 import java.util.ArrayList;
+import java.util.Optional;
 import java.util.logging.Logger;
 
 import tuteez.commons.core.LogsCenter;
@@ -40,6 +41,9 @@ public class AddRemarkCommand extends RemarkCommand {
 
         model.setPerson(personToUpdate, updatedPerson);
         model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
+
+        // Update the last viewed person in the model after updating remarks
+        model.updateLastViewedPerson(updatedPerson);
 
         return new CommandResult(String.format("Added remark to Person %1$s: %2$s",
                 personIndex.getOneBased(), remarkToAdd.toString()));

--- a/src/main/java/tuteez/logic/commands/AddRemarkCommand.java
+++ b/src/main/java/tuteez/logic/commands/AddRemarkCommand.java
@@ -1,7 +1,6 @@
 package tuteez.logic.commands;
 
 import java.util.ArrayList;
-import java.util.Optional;
 import java.util.logging.Logger;
 
 import tuteez.commons.core.LogsCenter;

--- a/src/main/java/tuteez/logic/commands/DeleteRemarkCommand.java
+++ b/src/main/java/tuteez/logic/commands/DeleteRemarkCommand.java
@@ -41,6 +41,9 @@ public class DeleteRemarkCommand extends RemarkCommand {
         model.setPerson(personToUpdate, updatedPerson);
         model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
 
+        // Update the last viewed person in the model after updating remarks
+        model.updateLastViewedPerson(updatedPerson);
+
         return new CommandResult(String.format("Deleted remark at index %1$s from Person %2$s",
                 remarkIndex.getOneBased(), personIndex.getOneBased()));
     }

--- a/src/main/java/tuteez/model/ModelManager.java
+++ b/src/main/java/tuteez/model/ModelManager.java
@@ -160,6 +160,8 @@ public class ModelManager implements Model {
     @Override
     public void updateLastViewedPerson(Person personOnDisplay) {
         requireNonNull(personOnDisplay);
+        // Clear existing person to ensure each time updateLastViewedPerson is called, personOnDisplay is updated
+        lastViewedPerson.set(Optional.empty());
         lastViewedPerson.set(Optional.of(personOnDisplay));
         logger.info("Last viewed person updated: " + personOnDisplay.getName().fullName);
     }

--- a/src/test/java/tuteez/logic/commands/AddRemarkCommandTest.java
+++ b/src/test/java/tuteez/logic/commands/AddRemarkCommandTest.java
@@ -90,6 +90,24 @@ public class AddRemarkCommandTest {
     }
 
     @Test
+    public void execute_addRemark_updatesLastViewedPerson() {
+        Person personToAddRemark = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person updatedPerson = new PersonBuilder(personToAddRemark).withRemarks(VALID_REMARKLIST).build();
+        AddRemarkCommand addRemarkCommand = new AddRemarkCommand(INDEX_FIRST_PERSON, VALID_REMARK);
+
+        String expectedMessage = String.format("Added remark to Person %1$s: %2$s",
+                INDEX_FIRST_PERSON.getOneBased(), VALID_REMARK);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(personToAddRemark, updatedPerson);
+
+        assertCommandSuccess(addRemarkCommand, model, expectedMessage, expectedModel);
+
+        assertTrue(model.getLastViewedPerson().get().isPresent(), "Expected lastViewedPerson to be set");
+        assertTrue(model.getLastViewedPerson().get().get().equals(updatedPerson));
+    }
+
+    @Test
     public void equals() {
         AddRemarkCommand addFirstRemarkCommand = new AddRemarkCommand(INDEX_FIRST_PERSON, VALID_REMARK);
         AddRemarkCommand addSecondRemarkCommand = new AddRemarkCommand(INDEX_SECOND_PERSON, VALID_REMARK);

--- a/src/test/java/tuteez/logic/commands/DeleteRemarkCommandTest.java
+++ b/src/test/java/tuteez/logic/commands/DeleteRemarkCommandTest.java
@@ -117,20 +117,23 @@ public class DeleteRemarkCommandTest {
     }
 
     @Test
-    public void execute_deleteRemark_updatesLastViewedPerson() throws Exception {
-        Person personToUpdate = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        RemarkList updatedRemarkList = new RemarkList(Arrays.asList(new Remark("First Remark"), new Remark("Second Remark")));
-        Person personWithRemarks = new PersonBuilder(personToUpdate).withRemarks(updatedRemarkList).build();
-        model.setPerson(personToUpdate, personWithRemarks);
+    public void execute_deleteRemark_updatesLastViewedPerson() {
+        Person originalPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person personToDeleteRemark = new PersonBuilder(originalPerson).withRemarks(VALID_REMARKLIST).build();
 
-        DeleteRemarkCommand deleteRemarkCommand = new DeleteRemarkCommand(INDEX_FIRST_PERSON, Index.fromZeroBased(0));
+        model.setPerson(originalPerson, personToDeleteRemark);
 
-        RemarkList expectedRemarkList = new RemarkList(Arrays.asList(new Remark("Second Remark")));
-        Person expectedPerson = new PersonBuilder(personToUpdate).withRemarks(expectedRemarkList).build();
+        DeleteRemarkCommand deleteRemarkCommand = new DeleteRemarkCommand(INDEX_FIRST_PERSON, INDEX_FIRST_REMARK);
 
-        deleteRemarkCommand.execute(model);
+        Person expectedPerson = new PersonBuilder(personToDeleteRemark).withRemarks(UPDATED_REMARKLIST).build();
 
-        assertTrue(model.getLastViewedPerson().get().isPresent(), "Expected lastViewedPerson to be set");
+        String expectedMessage = String.format("Deleted remark at index %1$s from Person %2$s", 1, 1);
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(personToDeleteRemark, expectedPerson);
+
+        assertCommandSuccess(deleteRemarkCommand, model, expectedMessage, expectedModel);
+
+        assertTrue(model.getLastViewedPerson().get().isPresent(), "Expected lastViewedPerson to be present");
         assertTrue(model.getLastViewedPerson().get().get().equals(expectedPerson),
                 "Expected lastViewedPerson to match the person with the updated remark list");
     }

--- a/src/test/java/tuteez/logic/commands/DeleteRemarkCommandTest.java
+++ b/src/test/java/tuteez/logic/commands/DeleteRemarkCommandTest.java
@@ -117,6 +117,25 @@ public class DeleteRemarkCommandTest {
     }
 
     @Test
+    public void execute_deleteRemark_updatesLastViewedPerson() throws Exception {
+        Person personToUpdate = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        RemarkList updatedRemarkList = new RemarkList(Arrays.asList(new Remark("First Remark"), new Remark("Second Remark")));
+        Person personWithRemarks = new PersonBuilder(personToUpdate).withRemarks(updatedRemarkList).build();
+        model.setPerson(personToUpdate, personWithRemarks);
+
+        DeleteRemarkCommand deleteRemarkCommand = new DeleteRemarkCommand(INDEX_FIRST_PERSON, Index.fromZeroBased(0));
+
+        RemarkList expectedRemarkList = new RemarkList(Arrays.asList(new Remark("Second Remark")));
+        Person expectedPerson = new PersonBuilder(personToUpdate).withRemarks(expectedRemarkList).build();
+
+        deleteRemarkCommand.execute(model);
+
+        assertTrue(model.getLastViewedPerson().get().isPresent(), "Expected lastViewedPerson to be set");
+        assertTrue(model.getLastViewedPerson().get().get().equals(expectedPerson),
+                "Expected lastViewedPerson to match the person with the updated remark list");
+    }
+
+    @Test
     public void equals() {
         DeleteRemarkCommand deleteFirstRemarkCommand = new DeleteRemarkCommand(INDEX_FIRST_PERSON,
                 Index.fromOneBased(1));


### PR DESCRIPTION
Fixes #136, #144 and #158
# What is this Pull Request for?
Currently, adding or deleting remarks does not display the student with updated remarks. Updating the UI to display the student with modified remarks will help user to better locate and view the changes. 

# What does this Pull Request do?
Updates the lastViewedPerson after an AddRemarkCommand or DeleteRemarkCommand is executed successfully such that we can display the updated the student.