### PR TITLE
Make command words case-insensitive

### DIFF
--- a/src/main/java/tuteez/logic/commands/AddRemarkCommand.java
+++ b/src/main/java/tuteez/logic/commands/AddRemarkCommand.java
@@ -1,6 +1,7 @@
 package tuteez.logic.commands;
 
 import java.util.ArrayList;
+import java.util.Optional;
 import java.util.logging.Logger;
 
 import tuteez.commons.core.LogsCenter;
@@ -40,6 +41,9 @@ public class AddRemarkCommand extends RemarkCommand {
 
         model.setPerson(personToUpdate, updatedPerson);
         model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
+
+        // Update the last viewed person in the model after updating remarks
+        model.updateLastViewedPerson(updatedPerson);
 
         return new CommandResult(String.format("Added remark to Person %1$s: %2$s",
                 personIndex.getOneBased(), remarkToAdd.toString()));

--- a/src/main/java/tuteez/logic/commands/AddRemarkCommand.java
+++ b/src/main/java/tuteez/logic/commands/AddRemarkCommand.java
@@ -1,7 +1,6 @@
 package tuteez.logic.commands;
 
 import java.util.ArrayList;
-import java.util.Optional;
 import java.util.logging.Logger;
 
 import tuteez.commons.core.LogsCenter;

--- a/src/main/java/tuteez/logic/commands/DeleteCommand.java
+++ b/src/main/java/tuteez/logic/commands/DeleteCommand.java
@@ -61,6 +61,15 @@ public class DeleteCommand extends Command {
             personToDelete = getPersonToDeleteByName(model, targetName);
         }
 
+        if (model.getLastViewedPerson().get().isPresent()) {
+            if (personToDelete.equals(model.getLastViewedPerson().get().get())) {
+                model.removeLastViewedPerson();
+                String logMessageForPerson =
+                        String.format("Student on display is deleted, Student: %s", personToDelete);
+                logger.info(logMessageForPerson);
+            }
+        }
+
         logger.info("Student deleted - " + personToDelete);
         model.deletePerson(personToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));

--- a/src/main/java/tuteez/logic/commands/DeleteRemarkCommand.java
+++ b/src/main/java/tuteez/logic/commands/DeleteRemarkCommand.java
@@ -41,6 +41,9 @@ public class DeleteRemarkCommand extends RemarkCommand {
         model.setPerson(personToUpdate, updatedPerson);
         model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
 
+        // Update the last viewed person in the model after updating remarks
+        model.updateLastViewedPerson(updatedPerson);
+
         return new CommandResult(String.format("Deleted remark at index %1$s from Person %2$s",
                 remarkIndex.getOneBased(), personIndex.getOneBased()));
     }

--- a/src/main/java/tuteez/logic/parser/AddressBookParser.java
+++ b/src/main/java/tuteez/logic/parser/AddressBookParser.java
@@ -45,7 +45,7 @@ public class AddressBookParser {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
         }
 
-        final String commandWord = matcher.group("commandWord");
+        final String commandWord = matcher.group("commandWord").toLowerCase();
         final String arguments = matcher.group("arguments");
 
         // Note to developers: Change the log level in config.json to enable lower level (i.e., FINE, FINER and lower)

--- a/src/main/java/tuteez/model/Model.java
+++ b/src/main/java/tuteez/model/Model.java
@@ -101,9 +101,14 @@ public interface Model {
     ObjectProperty<Optional<Person>> getLastViewedPerson();
 
     /**
-     * Updates the lastViewedPerson after a DisplayCommand is called.
+     * Updates the lastViewedPerson.
      */
     void updateLastViewedPerson(Person personOnDisplay);
+
+    /**
+     * Deletes the lastViewedPerson.
+     */
+    void removeLastViewedPerson();
 
     /**
      * Returns the {@code person} in the address book with the given name.

--- a/src/main/java/tuteez/model/ModelManager.java
+++ b/src/main/java/tuteez/model/ModelManager.java
@@ -160,6 +160,8 @@ public class ModelManager implements Model {
     @Override
     public void updateLastViewedPerson(Person personOnDisplay) {
         requireNonNull(personOnDisplay);
+        // Clear existing person to ensure each time updateLastViewedPerson is called, personOnDisplay is updated
+        lastViewedPerson.set(Optional.empty());
         lastViewedPerson.set(Optional.of(personOnDisplay));
         logger.info("Last viewed person updated: " + personOnDisplay.getName().fullName);
     }

--- a/src/main/java/tuteez/model/ModelManager.java
+++ b/src/main/java/tuteez/model/ModelManager.java
@@ -167,6 +167,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void removeLastViewedPerson() {
+        lastViewedPerson.set(Optional.empty());
+        logger.info("Last viewed person removed");
+    }
+
+    @Override
     public boolean equals(Object other) {
         if (other == this) {
             return true;

--- a/src/main/java/tuteez/model/person/lesson/Day.java
+++ b/src/main/java/tuteez/model/person/lesson/Day.java
@@ -18,23 +18,30 @@ public enum Day {
      */
     public static Day convertDayToEnum(String dayInStr) {
         switch (dayInStr) {
-        case "monday":
-            return MONDAY;
-        case "tuesday":
-            return TUESDAY;
-        case "wednesday":
-            return WEDNESDAY;
-        case "thursday":
-            return THURSDAY;
-        case "friday":
-            return FRIDAY;
-        case "saturday":
-            return SATURDAY;
-        case "sunday":
-            return SUNDAY;
-        default:
-            // This should not occur because input is validated before calling the method.
-            throw new IllegalArgumentException("Invalid day string: " + dayInStr);
+            case "monday":
+            case "mon":
+                return MONDAY;
+            case "tuesday":
+            case "tue":
+                return TUESDAY;
+            case "wednesday":
+            case "wed":
+                return WEDNESDAY;
+            case "thursday":
+            case "thu":
+                return THURSDAY;
+            case "friday":
+            case "fri":
+                return FRIDAY;
+            case "saturday":
+            case "sat":
+                return SATURDAY;
+            case "sunday":
+            case "sun":
+                return SUNDAY;
+            default:
+                // This should not occur because input is validated before calling the method.
+                throw new IllegalArgumentException("Invalid day string: " + dayInStr);
         }
     }
 

--- a/src/main/java/tuteez/model/person/lesson/Day.java
+++ b/src/main/java/tuteez/model/person/lesson/Day.java
@@ -18,15 +18,15 @@ public enum Day {
      */
     public static Day convertDayToEnum(String dayInStr) {
         return switch (dayInStr) {
-            case "monday", "mon" -> MONDAY;
-            case "tuesday", "tue" -> TUESDAY;
-            case "wednesday", "wed" -> WEDNESDAY;
-            case "thursday", "thu" -> THURSDAY;
-            case "friday", "fri" -> FRIDAY;
-            case "saturday", "sat" -> SATURDAY;
-            case "sunday", "sun" -> SUNDAY;
-            // Default case should not occur because input is validated before calling the method.
-            default -> throw new IllegalArgumentException("Invalid day string: " + dayInStr);
+        case "monday", "mon" -> MONDAY;
+        case "tuesday", "tue" -> TUESDAY;
+        case "wednesday", "wed" -> WEDNESDAY;
+        case "thursday", "thu" -> THURSDAY;
+        case "friday", "fri" -> FRIDAY;
+        case "saturday", "sat" -> SATURDAY;
+        case "sunday", "sun" -> SUNDAY;
+        // Default case should not occur because input is validated before calling the method.
+        default -> throw new IllegalArgumentException("Invalid day string: " + dayInStr);
         };
     }
 

--- a/src/main/java/tuteez/model/person/lesson/Day.java
+++ b/src/main/java/tuteez/model/person/lesson/Day.java
@@ -12,37 +12,22 @@ public enum Day {
      * <p>The string must be in lowercase (e.g., "monday", "tuesday"). If the string does not
      * match any of the valid days of the week, an exception is thrown.</p>
      *
-     * @param dayInStr The string representing the day of the week (e.g., "monday").
+     * @param dayInStr The string representing the day of the week (e.g., "monday", "mon").
      * @return The {@code Day} enum corresponding to the input string.
      * @throws IllegalArgumentException If the provided string does not match a valid day.
      */
     public static Day convertDayToEnum(String dayInStr) {
-        switch (dayInStr) {
-            case "monday":
-            case "mon":
-                return MONDAY;
-            case "tuesday":
-            case "tue":
-                return TUESDAY;
-            case "wednesday":
-            case "wed":
-                return WEDNESDAY;
-            case "thursday":
-            case "thu":
-                return THURSDAY;
-            case "friday":
-            case "fri":
-                return FRIDAY;
-            case "saturday":
-            case "sat":
-                return SATURDAY;
-            case "sunday":
-            case "sun":
-                return SUNDAY;
-            default:
-                // This should not occur because input is validated before calling the method.
-                throw new IllegalArgumentException("Invalid day string: " + dayInStr);
-        }
+        return switch (dayInStr) {
+            case "monday", "mon" -> MONDAY;
+            case "tuesday", "tue" -> TUESDAY;
+            case "wednesday", "wed" -> WEDNESDAY;
+            case "thursday", "thu" -> THURSDAY;
+            case "friday", "fri" -> FRIDAY;
+            case "saturday", "sat" -> SATURDAY;
+            case "sunday", "sun" -> SUNDAY;
+            // Default case should not occur because input is validated before calling the method.
+            default -> throw new IllegalArgumentException("Invalid day string: " + dayInStr);
+        };
     }
 
     @Override

--- a/src/main/java/tuteez/model/person/lesson/Lesson.java
+++ b/src/main/java/tuteez/model/person/lesson/Lesson.java
@@ -27,26 +27,6 @@ public class Lesson {
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HHmm");
     private static final String VALID_TIME_RANGE_REGEX = "([01]?[0-9]|2[0-3])[0-5][0-9]-([01]?[0-9]|2[0-3])[0-5][0-9]";
     private static final DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HHmm");
-    private final Day lessonDay;
-    private final LocalTime startTime;
-    private final LocalTime endTime;
-
-
-    /**
-     * Constructs a {@code Lesson}.
-     *
-     * @param lesson A valid lesson string containing day and time range.
-     */
-    public Lesson(String lesson) {
-        requireNonNull(lesson);
-        checkArgument(isValidLesson(lesson), MESSAGE_CONSTRAINTS);
-        String[] lessonDayTimeArr = lesson.split("\\s+", 2);
-        String[] timeArr = lessonDayTimeArr[1].split("-");
-        this.lessonDay = Day.convertDayToEnum(lessonDayTimeArr[0].toLowerCase());
-        this.startTime = LocalTime.parse(timeArr[0], timeFormatter);
-        this.endTime = LocalTime.parse(timeArr[1], timeFormatter);
-    }
-
     /**
      * Maps various string representations of days (e.g., "monday", "mon") to their corresponding Day enum values.
      * All keys are stored in lowercase.
@@ -67,6 +47,25 @@ public class Lesson {
         DAY_NAME_MAP.put("sat", Day.SATURDAY);
         DAY_NAME_MAP.put("sunday", Day.SUNDAY);
         DAY_NAME_MAP.put("sun", Day.SUNDAY);
+    }
+    private final Day lessonDay;
+    private final LocalTime startTime;
+    private final LocalTime endTime;
+
+
+    /**
+     * Constructs a {@code Lesson}.
+     *
+     * @param lesson A valid lesson string containing day and time range.
+     */
+    public Lesson(String lesson) {
+        requireNonNull(lesson);
+        checkArgument(isValidLesson(lesson), MESSAGE_CONSTRAINTS);
+        String[] lessonDayTimeArr = lesson.split("\\s+", 2);
+        String[] timeArr = lessonDayTimeArr[1].split("-");
+        this.lessonDay = Day.convertDayToEnum(lessonDayTimeArr[0].toLowerCase());
+        this.startTime = LocalTime.parse(timeArr[0], timeFormatter);
+        this.endTime = LocalTime.parse(timeArr[1], timeFormatter);
     }
 
     /**

--- a/src/main/java/tuteez/model/person/lesson/Lesson.java
+++ b/src/main/java/tuteez/model/person/lesson/Lesson.java
@@ -5,7 +5,10 @@ import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON;
 
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 
 
 /**
@@ -37,13 +40,17 @@ public class Lesson {
     public Lesson(String lesson) {
         requireNonNull(lesson);
         checkArgument(isValidLesson(lesson), MESSAGE_CONSTRAINTS);
-        String[] lessonDayTimeArr = lesson.split(" ");
+        String[] lessonDayTimeArr = lesson.split("\\s+", 2);
         String[] timeArr = lessonDayTimeArr[1].split("-");
         this.lessonDay = Day.convertDayToEnum(lessonDayTimeArr[0].toLowerCase());
         this.startTime = LocalTime.parse(timeArr[0], timeFormatter);
         this.endTime = LocalTime.parse(timeArr[1], timeFormatter);
     }
 
+    /**
+     * Maps various string representations of days (e.g., "monday", "mon") to their corresponding Day enum values.
+     * All keys are stored in lowercase.
+     */
     private static final Map<String, Day> DAY_NAME_MAP = new HashMap<>();
     static {
         DAY_NAME_MAP.put("monday", Day.MONDAY);
@@ -111,7 +118,7 @@ public class Lesson {
      *          false otherwise.
      */
     public static boolean isValidLesson(String lesson) {
-        String[] parts = lesson.split(" ", 2);
+        String[] parts = lesson.split("\\s+", 2);
         if (parts.length != 2) {
             return false;
         }

--- a/src/main/java/tuteez/model/person/lesson/Lesson.java
+++ b/src/main/java/tuteez/model/person/lesson/Lesson.java
@@ -5,9 +5,7 @@ import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON;
 
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.Objects;
+import java.util.*;
 
 
 /**
@@ -46,6 +44,24 @@ public class Lesson {
         this.endTime = LocalTime.parse(timeArr[1], timeFormatter);
     }
 
+    private static final Map<String, Day> DAY_NAME_MAP = new HashMap<>();
+    static {
+        DAY_NAME_MAP.put("monday", Day.MONDAY);
+        DAY_NAME_MAP.put("mon", Day.MONDAY);
+        DAY_NAME_MAP.put("tuesday", Day.TUESDAY);
+        DAY_NAME_MAP.put("tue", Day.TUESDAY);
+        DAY_NAME_MAP.put("wednesday", Day.WEDNESDAY);
+        DAY_NAME_MAP.put("wed", Day.WEDNESDAY);
+        DAY_NAME_MAP.put("thursday", Day.THURSDAY);
+        DAY_NAME_MAP.put("thu", Day.THURSDAY);
+        DAY_NAME_MAP.put("friday", Day.FRIDAY);
+        DAY_NAME_MAP.put("fri", Day.FRIDAY);
+        DAY_NAME_MAP.put("saturday", Day.SATURDAY);
+        DAY_NAME_MAP.put("sat", Day.SATURDAY);
+        DAY_NAME_MAP.put("sunday", Day.SUNDAY);
+        DAY_NAME_MAP.put("sun", Day.SUNDAY);
+    }
+
     /**
      * Validates if the day provided is valid (i.e., part of the defined Days enum).
      *
@@ -53,8 +69,7 @@ public class Lesson {
      * @return true if the day is valid.
      */
     private static boolean isValidDay(String day) {
-        return Arrays.stream(Day.values())
-                .anyMatch(d -> d.name().equalsIgnoreCase(day));
+        return DAY_NAME_MAP.containsKey(day.toLowerCase());
     }
 
     /**
@@ -146,7 +161,7 @@ public class Lesson {
      *
      * @param other The object to compare for equality.
      * @return {@code true} if the other object is a {@code Lesson} and has the same
-     *         start and end times as this lesson, {@code false} otherwise.
+     *         say, start and end times as this lesson, {@code false} otherwise.
      */
     @Override
     public boolean equals(Object other) {
@@ -159,7 +174,9 @@ public class Lesson {
         }
 
         Lesson otherLesson = (Lesson) other;
-        return otherLesson.startTime.equals(this.startTime) && otherLesson.endTime.equals(this.endTime);
+        return otherLesson.lessonDay.equals(this.lessonDay)
+                && otherLesson.startTime.equals(this.startTime)
+                && otherLesson.endTime.equals(this.endTime);
     }
 
     @Override

--- a/src/test/java/tuteez/logic/commands/AddCommandTest.java
+++ b/src/test/java/tuteez/logic/commands/AddCommandTest.java
@@ -192,6 +192,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void removeLastViewedPerson() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public Person findPersonByName(Name name) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/tuteez/logic/commands/AddRemarkCommandTest.java
+++ b/src/test/java/tuteez/logic/commands/AddRemarkCommandTest.java
@@ -90,6 +90,24 @@ public class AddRemarkCommandTest {
     }
 
     @Test
+    public void execute_addRemark_updatesLastViewedPerson() {
+        Person personToAddRemark = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person updatedPerson = new PersonBuilder(personToAddRemark).withRemarks(VALID_REMARKLIST).build();
+        AddRemarkCommand addRemarkCommand = new AddRemarkCommand(INDEX_FIRST_PERSON, VALID_REMARK);
+
+        String expectedMessage = String.format("Added remark to Person %1$s: %2$s",
+                INDEX_FIRST_PERSON.getOneBased(), VALID_REMARK);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(personToAddRemark, updatedPerson);
+
+        assertCommandSuccess(addRemarkCommand, model, expectedMessage, expectedModel);
+
+        assertTrue(model.getLastViewedPerson().get().isPresent(), "Expected lastViewedPerson to be set");
+        assertTrue(model.getLastViewedPerson().get().get().equals(updatedPerson));
+    }
+
+    @Test
     public void equals() {
         AddRemarkCommand addFirstRemarkCommand = new AddRemarkCommand(INDEX_FIRST_PERSON, VALID_REMARK);
         AddRemarkCommand addSecondRemarkCommand = new AddRemarkCommand(INDEX_SECOND_PERSON, VALID_REMARK);

--- a/src/test/java/tuteez/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/tuteez/logic/commands/DeleteCommandTest.java
@@ -108,6 +108,52 @@ public class DeleteCommandTest {
     }
 
     @Test
+    public void execute_deleteLastViewedPerson_removesLastViewedPerson() {
+        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+
+        model.updateLastViewedPerson(personToDelete);
+        expectedModel.updateLastViewedPerson(personToDelete);
+
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+                Messages.format(personToDelete));
+
+        expectedModel.deletePerson(personToDelete);
+        expectedModel.removeLastViewedPerson();
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+
+        // Verify last viewed person was removed
+        assertFalse(model.getLastViewedPerson().get().isPresent(),
+                "Expected last viewed person to be removed after deleting the viewed person");
+    }
+
+    @Test
+    public void execute_deleteNonLastViewedPerson_keepsLastViewedPerson() {
+        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person lastViewedPerson = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+
+        model.updateLastViewedPerson(lastViewedPerson);
+        expectedModel.updateLastViewedPerson(lastViewedPerson);
+
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+                Messages.format(personToDelete));
+
+        expectedModel.deletePerson(personToDelete);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+
+        // Verify last viewed person was not removed
+        assertTrue(model.getLastViewedPerson().get().isPresent(),
+                "Expected last viewed person to be retained when deleting a different person");
+        assertEquals(lastViewedPerson, model.getLastViewedPerson().get().get(),
+                "Expected last viewed person to remain unchanged");
+    }
+
+    @Test
     public void equals() {
         DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_PERSON);
         DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_PERSON);

--- a/src/test/java/tuteez/logic/commands/DeleteRemarkCommandTest.java
+++ b/src/test/java/tuteez/logic/commands/DeleteRemarkCommandTest.java
@@ -117,20 +117,23 @@ public class DeleteRemarkCommandTest {
     }
 
     @Test
-    public void execute_deleteRemark_updatesLastViewedPerson() throws Exception {
-        Person personToUpdate = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        RemarkList updatedRemarkList = new RemarkList(Arrays.asList(new Remark("First Remark"), new Remark("Second Remark")));
-        Person personWithRemarks = new PersonBuilder(personToUpdate).withRemarks(updatedRemarkList).build();
-        model.setPerson(personToUpdate, personWithRemarks);
+    public void execute_deleteRemark_updatesLastViewedPerson() {
+        Person originalPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person personToDeleteRemark = new PersonBuilder(originalPerson).withRemarks(VALID_REMARKLIST).build();
 
-        DeleteRemarkCommand deleteRemarkCommand = new DeleteRemarkCommand(INDEX_FIRST_PERSON, Index.fromZeroBased(0));
+        model.setPerson(originalPerson, personToDeleteRemark);
 
-        RemarkList expectedRemarkList = new RemarkList(Arrays.asList(new Remark("Second Remark")));
-        Person expectedPerson = new PersonBuilder(personToUpdate).withRemarks(expectedRemarkList).build();
+        DeleteRemarkCommand deleteRemarkCommand = new DeleteRemarkCommand(INDEX_FIRST_PERSON, INDEX_FIRST_REMARK);
 
-        deleteRemarkCommand.execute(model);
+        Person expectedPerson = new PersonBuilder(personToDeleteRemark).withRemarks(UPDATED_REMARKLIST).build();
 
-        assertTrue(model.getLastViewedPerson().get().isPresent(), "Expected lastViewedPerson to be set");
+        String expectedMessage = String.format("Deleted remark at index %1$s from Person %2$s", 1, 1);
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(personToDeleteRemark, expectedPerson);
+
+        assertCommandSuccess(deleteRemarkCommand, model, expectedMessage, expectedModel);
+
+        assertTrue(model.getLastViewedPerson().get().isPresent(), "Expected lastViewedPerson to be present");
         assertTrue(model.getLastViewedPerson().get().get().equals(expectedPerson),
                 "Expected lastViewedPerson to match the person with the updated remark list");
     }

--- a/src/test/java/tuteez/logic/commands/DeleteRemarkCommandTest.java
+++ b/src/test/java/tuteez/logic/commands/DeleteRemarkCommandTest.java
@@ -117,6 +117,25 @@ public class DeleteRemarkCommandTest {
     }
 
     @Test
+    public void execute_deleteRemark_updatesLastViewedPerson() throws Exception {
+        Person personToUpdate = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        RemarkList updatedRemarkList = new RemarkList(Arrays.asList(new Remark("First Remark"), new Remark("Second Remark")));
+        Person personWithRemarks = new PersonBuilder(personToUpdate).withRemarks(updatedRemarkList).build();
+        model.setPerson(personToUpdate, personWithRemarks);
+
+        DeleteRemarkCommand deleteRemarkCommand = new DeleteRemarkCommand(INDEX_FIRST_PERSON, Index.fromZeroBased(0));
+
+        RemarkList expectedRemarkList = new RemarkList(Arrays.asList(new Remark("Second Remark")));
+        Person expectedPerson = new PersonBuilder(personToUpdate).withRemarks(expectedRemarkList).build();
+
+        deleteRemarkCommand.execute(model);
+
+        assertTrue(model.getLastViewedPerson().get().isPresent(), "Expected lastViewedPerson to be set");
+        assertTrue(model.getLastViewedPerson().get().get().equals(expectedPerson),
+                "Expected lastViewedPerson to match the person with the updated remark list");
+    }
+
+    @Test
     public void equals() {
         DeleteRemarkCommand deleteFirstRemarkCommand = new DeleteRemarkCommand(INDEX_FIRST_PERSON,
                 Index.fromOneBased(1));

--- a/src/test/java/tuteez/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/tuteez/logic/parser/AddressBookParserTest.java
@@ -138,4 +138,14 @@ public class AddressBookParserTest {
     public void parseCommand_unknownCommand_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
     }
+
+    @Test
+    void parseCommand_clearCommand_caseInsensitive() throws Exception {
+        String[] variations = {"clear", "Clear", "CLEAR", "cLear", "CleaR", "clear ", "   CLEAR   "};
+        for (String variation : variations) {
+            assertTrue(parser.parseCommand(variation) instanceof ClearCommand);
+            assertTrue(parser.parseCommand(variation + " 3") instanceof ClearCommand);
+
+        }
+    }
 }

--- a/src/test/java/tuteez/model/person/lesson/LessonTest.java
+++ b/src/test/java/tuteez/model/person/lesson/LessonTest.java
@@ -53,6 +53,38 @@ public class LessonTest {
     }
 
     @Test
+    public void isValidLesson_acceptsMultipleSpacesBetweenDayAndTime() {
+        String lessonWithOneSpace = "monday 1200-1400";
+        String lessonWithTwoSpaces = "monday  1200-1400";
+
+        assertTrue(isValidLesson(lessonWithOneSpace));
+        assertTrue(isValidLesson(lessonWithTwoSpaces));
+    }
+
+    @Test
+    public void constructor_lessonStringWithMultipleSpaces_parsesSuccessfully() {
+        String lessonWithTwoSpaces = "monday  1200-1400";
+        String lessonWithManySpaces = "monday    1200-1400";
+        String lessonWithTabAndSpaces = "monday \t  1200-1400";
+
+        Lesson lessonTwo = new Lesson(lessonWithTwoSpaces);
+        Lesson lessonMany = new Lesson(lessonWithManySpaces);
+        Lesson lessonTab = new Lesson(lessonWithTabAndSpaces);
+
+        assertEquals(Day.MONDAY, lessonTwo.getLessonDay());
+        assertEquals("MONDAY 1200-1400", lessonTwo.getDayAndTime());
+        assertTrue(isValidLesson(lessonWithTwoSpaces));
+
+        assertEquals(Day.MONDAY, lessonMany.getLessonDay());
+        assertEquals("MONDAY 1200-1400", lessonMany.getDayAndTime());
+        assertTrue(isValidLesson(lessonWithManySpaces));
+
+        assertEquals(Day.MONDAY, lessonTab.getLessonDay());
+        assertEquals("MONDAY 1200-1400", lessonTab.getDayAndTime());
+        assertTrue(isValidLesson(lessonWithTabAndSpaces));
+    }
+
+    @Test
     public void constructor_acceptsShortcutDayNames() {
         String lessonWithShortCut = "mon 1200-1400";
         Lesson l1 = new Lesson("monday 1200-1400");

--- a/src/test/java/tuteez/model/person/lesson/LessonTest.java
+++ b/src/test/java/tuteez/model/person/lesson/LessonTest.java
@@ -3,6 +3,7 @@ package tuteez.model.person.lesson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static tuteez.model.person.lesson.Lesson.isValidLesson;
 import static tuteez.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Assertions;
@@ -49,6 +50,16 @@ public class LessonTest {
         assertTrue(Lesson.isClashingWithOtherLesson(l2, l1));
         assertTrue(Lesson.isClashingWithOtherLesson(l3, l4));
         assertTrue(Lesson.isClashingWithOtherLesson(l5, l6));
+    }
+
+    @Test
+    public void constructor_acceptsShortcutDayNames() {
+        String lessonWithShortCut = "mon 1200-1400";
+        Lesson l1 = new Lesson("monday 1200-1400");
+        Lesson l2 = new Lesson(lessonWithShortCut);
+
+        assertTrue(isValidLesson(lessonWithShortCut));
+        assertEquals(l1, l2);
     }
 
     @Test


### PR DESCRIPTION
Fixes #148 

# What is this PR for?
Previously, all non-lowercased command words entered results in "Unknown command". Parser handled command words with case-sensitivity.

# What this PR does
Made commands case-insensitive. 