### PR TITLE
Add method to retrieve a student's next lesson

### DIFF
--- a/src/main/java/tuteez/logic/commands/AddCommand.java
+++ b/src/main/java/tuteez/logic/commands/AddCommand.java
@@ -11,8 +11,8 @@ import static tuteez.logic.parser.CliSyntax.PREFIX_TELEGRAM;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.logging.Logger;
 
 import tuteez.commons.core.LogsCenter;
@@ -75,9 +75,9 @@ public class AddCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
-        Set<Lesson> lessonSet = toAdd.getLessons();
+        List<Lesson> lessonLst = toAdd.getLessons();
         Map<Person, ArrayList<Lesson>> resultMap = new HashMap<>();
-        for (Lesson lesson: lessonSet) {
+        for (Lesson lesson: lessonLst) {
             assert lesson != null;
             Map<Person, ArrayList<Lesson>> clashingLessons = model.getClashingLessons(lesson);
 

--- a/src/main/java/tuteez/logic/commands/EditCommand.java
+++ b/src/main/java/tuteez/logic/commands/EditCommand.java
@@ -99,7 +99,7 @@ public class EditCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
-        Optional<Set<Lesson>> lessons = editPersonDescriptor.getLessons();
+        Optional<List<Lesson>> lessons = editPersonDescriptor.getLessons();
         if (lessons.isPresent()) {
             Map<Person, ArrayList<Lesson>> resultMap = new HashMap<>();
             for (Lesson newlesson: lessons.get()) {
@@ -164,7 +164,7 @@ public class EditCommand extends Command {
         TelegramUsername updatedTelegramUser = editPersonDescriptor.getTelegramUsername()
                 .orElse(personToEdit.getTelegramUsername());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
-        Set<Lesson> updatedLessons = editPersonDescriptor.getLessons().orElse(personToEdit.getLessons());
+        List<Lesson> updatedLessons = editPersonDescriptor.getLessons().orElse(personToEdit.getLessons());
 
         RemarkList originalRemarkList = personToEdit.getRemarkList();
 
@@ -207,7 +207,7 @@ public class EditCommand extends Command {
         private Address address;
         private Set<Tag> tags;
         private TelegramUsername telegramUsername;
-        private Set<Lesson> lessons;
+        private List<Lesson> lessons;
 
 
         public EditPersonDescriptor() {}
@@ -295,8 +295,8 @@ public class EditCommand extends Command {
          * Sets {@code lessons} to this object's {@code lessons}.
          * A defensive copy of {@code lessons} is used internally.
          */
-        public void setLessons(Set<Lesson> lessons) {
-            this.lessons = (lessons != null) ? new HashSet<>(lessons) : null;
+        public void setLessons(List<Lesson> lessons) {
+            this.lessons = (lessons != null) ? new ArrayList<>(lessons) : null;
         }
 
         /**
@@ -304,8 +304,8 @@ public class EditCommand extends Command {
          * if modification is attempted.
          * Returns {@code Optional#empty()} if {@code lessons} is null.
          */
-        public Optional<Set<Lesson>> getLessons() {
-            return (lessons != null) ? Optional.of(Collections.unmodifiableSet(lessons)) : Optional.empty();
+        public Optional<List<Lesson>> getLessons() {
+            return (lessons != null) ? Optional.of(Collections.unmodifiableList(lessons)) : Optional.empty();
         }
 
         @Override

--- a/src/main/java/tuteez/logic/parser/AddCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/AddCommandParser.java
@@ -9,6 +9,7 @@ import static tuteez.logic.parser.CliSyntax.PREFIX_PHONE;
 import static tuteez.logic.parser.CliSyntax.PREFIX_TAG;
 import static tuteez.logic.parser.CliSyntax.PREFIX_TELEGRAM;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -53,7 +54,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                 argMultimap.getValue(PREFIX_TELEGRAM).orElse(null));
 
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
-        Set<Lesson> lessonList = ParserUtil.parseLessons(argMultimap.getAllValues(PREFIX_LESSON));
+        List<Lesson> lessonList = ParserUtil.parseLessons(argMultimap.getAllValues(PREFIX_LESSON));
 
         Person person = new Person(name, phone, email, address, telegramUsername, tagList, lessonList);
 

--- a/src/main/java/tuteez/logic/parser/EditCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/EditCommandParser.java
@@ -12,6 +12,7 @@ import static tuteez.logic.parser.CliSyntax.PREFIX_TELEGRAM;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -127,14 +128,14 @@ public class EditCommandParser implements Parser<EditCommand> {
      * If {@code lessons} contain only one element which is an empty string, it will be parsed into a
      * {@code Set<Lesson>} containing zero lessons.
      */
-    private Optional<Set<Lesson>> parseLessonsForEdit(Collection<String> lessons) throws ParseException {
+    private Optional<List<Lesson>> parseLessonsForEdit(Collection<String> lessons) throws ParseException {
         assert lessons != null;
 
         if (lessons.isEmpty()) {
             return Optional.empty();
         }
-        Collection<String> lessonSet = lessons.size() == 1 && lessons.contains("") ? Collections.emptySet() : lessons;
-        return Optional.of(ParserUtil.parseLessons(lessonSet));
+        Collection<String> lessonLst = lessons.size() == 1 && lessons.contains("") ? Collections.emptySet() : lessons;
+        return Optional.of(ParserUtil.parseLessons(lessonLst));
     }
 
 }

--- a/src/main/java/tuteez/logic/parser/ParserUtil.java
+++ b/src/main/java/tuteez/logic/parser/ParserUtil.java
@@ -2,8 +2,10 @@ package tuteez.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import tuteez.commons.core.index.Index;
@@ -166,9 +168,9 @@ public class ParserUtil {
     /**
      * Parses {@code Collection<String> lessons} into a {@code Set<Lesson>}.
      */
-    public static Set<Lesson> parseLessons(Collection<String> lessons) throws ParseException {
+    public static List<Lesson> parseLessons(Collection<String> lessons) throws ParseException {
         requireNonNull(lessons);
-        final Set<Lesson> lessonSet = new HashSet<>();
+        final List<Lesson> lessonSet = new ArrayList<>();
         for (String lesson : lessons) {
             lessonSet.add(parseLesson(lesson));
         }

--- a/src/main/java/tuteez/model/person/Person.java
+++ b/src/main/java/tuteez/model/person/Person.java
@@ -2,13 +2,16 @@ package tuteez.model.person;
 
 import static tuteez.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
 import tuteez.commons.util.ToStringBuilder;
+import tuteez.model.person.lesson.Day;
 import tuteez.model.person.lesson.Lesson;
 import tuteez.model.remark.RemarkList;
 import tuteez.model.tag.Tag;
@@ -53,6 +56,7 @@ public class Person {
      */
     public Person(Name name, Phone phone, Email email, Address address, TelegramUsername teleHandle, Set<Tag> tags,
                   Set<Lesson> lessons, RemarkList remarkList) {
+                  List<Lesson> lessons, RemarkList remarkList) {
         requireAllNonNull(name, phone, email, address, tags);
         this.name = name;
         this.phone = phone;
@@ -104,6 +108,8 @@ public class Person {
      */
     public Set<Lesson> getLessons() {
         return Collections.unmodifiableSet(lessons);
+    public List<Lesson> getLessons() {
+        return Collections.unmodifiableList(lessons);
     }
 
     public ArrayList<Lesson> getLessonsThatClash(Lesson otherLesson) {
@@ -128,6 +134,7 @@ public class Person {
         return otherPerson != null
                 && otherPerson.getName().equals(getName());
     }
+
     /**
      * Determines whether the specified lesson is already present in the student's schedule.
      *
@@ -136,6 +143,30 @@ public class Person {
      */
     public boolean isLessonScheduled(Lesson lesson) {
         return lessons.contains(lesson);
+    }
+
+    /**
+     * Determines a student's next lesson based on the current date and time.
+     *
+     * <p>This method iterates through all lessons and calculates the time remaining
+     * until each lesson starts, selecting the lesson with the shortest time until its
+     * start. The lesson that begins the soonest after the current time is returned.</p>
+     *
+     * @return The {@code Lesson} object that represents the next upcoming lesson
+     *         relative to the current date and time, or {@code null} if no lessons are scheduled.
+     */
+    public Lesson nextLessonBasedOnCurrentTime() {
+        Lesson nextLesson = null;
+        Duration shortestDuration = Duration.ofDays(Day.values().length);
+
+        for (Lesson ls : lessons) {
+            Duration durationTillLesson = ls.durationTillLesson();
+            if (durationTillLesson.compareTo(shortestDuration) < 0) {
+                nextLesson = ls;
+                shortestDuration = durationTillLesson;
+            }
+        }
+        return nextLesson;
     }
 
     public boolean hasSameName(Person otherStudent) {

--- a/src/main/java/tuteez/model/person/Person.java
+++ b/src/main/java/tuteez/model/person/Person.java
@@ -31,14 +31,14 @@ public class Person {
     // Data fields
     private final Address address;
     private final Set<Tag> tags = new HashSet<>();
-    private final Set<Lesson> lessons = new HashSet<>();
+    private final List<Lesson> lessons = new ArrayList<>();
     private final RemarkList remarkList;
 
     /**
      * Every field must be present and not null.
      */
     public Person(Name name, Phone phone, Email email, Address address, TelegramUsername teleHandle, Set<Tag> tags,
-                  Set<Lesson> lessons) {
+                  List<Lesson> lessons) {
         requireAllNonNull(name, phone, email, address, teleHandle, tags, lessons);
 
         this.name = name;
@@ -55,7 +55,6 @@ public class Person {
      * Returns a person object.
      */
     public Person(Name name, Phone phone, Email email, Address address, TelegramUsername teleHandle, Set<Tag> tags,
-                  Set<Lesson> lessons, RemarkList remarkList) {
                   List<Lesson> lessons, RemarkList remarkList) {
         requireAllNonNull(name, phone, email, address, tags);
         this.name = name;
@@ -106,8 +105,6 @@ public class Person {
      * Returns an immutable lesson set, which throws {@code UnsupportedOperationException}
      * if modification is attempted.
      */
-    public Set<Lesson> getLessons() {
-        return Collections.unmodifiableSet(lessons);
     public List<Lesson> getLessons() {
         return Collections.unmodifiableList(lessons);
     }

--- a/src/main/java/tuteez/model/person/lesson/Day.java
+++ b/src/main/java/tuteez/model/person/lesson/Day.java
@@ -30,6 +30,10 @@ public enum Day {
         };
     }
 
+    public int getValue() {
+        return ordinal() + 1;
+    }
+
     @Override
     public String toString() {
         return name();

--- a/src/main/java/tuteez/model/person/lesson/Lesson.java
+++ b/src/main/java/tuteez/model/person/lesson/Lesson.java
@@ -3,6 +3,8 @@ import static java.util.Objects.requireNonNull;
 import static tuteez.commons.util.AppUtil.checkArgument;
 import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
@@ -151,12 +153,72 @@ public class Lesson {
     }
 
     /**
+     * Calculates the duration until the next occurrence of the lesson.
+     * If the lesson is currently ongoing, this method returns a zero duration.
+     *
+     * <p>The duration calculation considers both the day of the week and the time of day.
+     * If the current day matches the lesson day but the current time is after the lesson's end time,
+     * the method assumes the next lesson will occur in one week from the current day.</p>
+     *
+     * @return A {@code Duration} representing the time left until the next lesson,
+     *         or zero if the lesson is currently ongoing.
+     */
+    public Duration durationTillLesson() {
+        if (this.isCurrentlyOngoing()) {
+            return Duration.ofDays(0).plusHours(0).plusMinutes(0);
+        }
+
+        LocalDateTime currentDateTime = LocalDateTime.now();
+        Day currentDay = Day.convertDayToEnum(currentDateTime.getDayOfWeek().toString().toLowerCase());
+        LocalTime currentTime = currentDateTime.toLocalTime();
+
+        int daysUntilLesson = (lessonDay.getValue() - currentDay.getValue() + 7) % 7;
+        if (currentDay == lessonDay && currentTime.isAfter(endTime)) {
+            daysUntilLesson = 7;
+        }
+
+        LocalDateTime nextLessonDateTime = currentDateTime
+                .plusDays(daysUntilLesson)
+                .withHour(startTime.getHour())
+                .withMinute(startTime.getMinute());
+        return Duration.between(currentDateTime, nextLessonDateTime);
+    }
+
+
+    /**
+     * Determines if the lesson is currently ongoing.
+     *
+     * <p>A lesson is considered ongoing if the current day matches the lesson's scheduled day,
+     * and the current time is between the lesson's start time and end time. If the current time
+     * coincides exactly with either the lesson's start time or end time, it is still considered
+     * to be ongoing, providing flexibility for timing precision.</p>
+     *
+     * @return {@code true} if the lesson is ongoing; {@code false} otherwise.
+     */
+    public boolean isCurrentlyOngoing() {
+        LocalDateTime currentDateTime = LocalDateTime.now();
+        Day currentDay = Day.convertDayToEnum(currentDateTime.getDayOfWeek().toString().toLowerCase());
+        LocalTime currentTime = currentDateTime.toLocalTime();
+        return currentDay.equals(lessonDay)
+                && currentTime.isAfter(startTime)
+                && currentTime.isBefore(endTime.plusMinutes(1));
+    }
+
+    /**
      * Returns the day on which this lesson occurs.
      *
      * @return The {@code Day} enum representing the day of the week for this lesson.
      */
     public Day getLessonDay() {
         return lessonDay;
+    }
+
+    public LocalTime getStartTime() {
+        return startTime;
+    }
+
+    public LocalTime getEndTime() {
+        return endTime;
     }
 
     /**

--- a/src/main/java/tuteez/model/util/SampleDataUtil.java
+++ b/src/main/java/tuteez/model/util/SampleDataUtil.java
@@ -1,6 +1,7 @@
 package tuteez.model.util;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -23,22 +24,22 @@ public class SampleDataUtil {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"), TelegramUsername.of("alex_yeoh"),
-                getTagSet("Chemistry"), getLessonSet("monday 0900-1000")),
+                getTagSet("Chemistry"), getLessonLst("monday 0900-1000")),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), TelegramUsername.of("bernice_yu"),
-                getTagSet("Physics"), getLessonSet("tuesday 1000-1100")),
+                getTagSet("Physics"), getLessonLst("tuesday 1000-1100")),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), TelegramUsername.of("charlotte_oliveiro"),
-                getTagSet("Math"), getLessonSet("wednesday 1000-1200")),
+                getTagSet("Math"), getLessonLst("wednesday 1000-1200")),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), TelegramUsername.of("david_li"),
-                getTagSet("English"), getLessonSet("friday 1000-1100")),
+                getTagSet("English"), getLessonLst("friday 1000-1100")),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"), TelegramUsername.of("irfan_ibrahim"),
-                getTagSet("Biology"), getLessonSet("saturday 0900-1100")),
+                getTagSet("Biology"), getLessonLst("saturday 0900-1100")),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"), TelegramUsername.of("roy_balakrishnan"),
-                getTagSet("Science"), getLessonSet("sunday 0900-1100"))
+                getTagSet("Science"), getLessonLst("sunday 0900-1100"))
         };
     }
 
@@ -62,10 +63,9 @@ public class SampleDataUtil {
     /**
      * Returns a Lesson set containing the list of strings given.
      */
-    public static Set<Lesson> getLessonSet(String... strings) {
+    public static List<Lesson> getLessonLst(String... strings) {
         return Arrays.stream(strings)
                 .map(Lesson::new)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toList());
     }
-
 }

--- a/src/main/java/tuteez/storage/JsonAdaptedPerson.java
+++ b/src/main/java/tuteez/storage/JsonAdaptedPerson.java
@@ -99,7 +99,7 @@ class JsonAdaptedPerson {
 
         final Set<Tag> modelTags = getModelTags(tags);
 
-        final Set<Lesson> modelLessons = getModelLessons(lessons);
+        final List<Lesson> modelLessons = getModelLessons(lessons);
 
         return new Person(modelName, modelPhone, modelEmail, modelAddress, modelTelegramUsername, modelTags,
                 modelLessons, modelRemarkList);
@@ -157,12 +157,12 @@ class JsonAdaptedPerson {
         return new HashSet<>(personTags);
     }
 
-    private Set<Lesson> getModelLessons(List<JsonAdaptedLesson> lessons) throws IllegalValueException {
+    private List<Lesson> getModelLessons(List<JsonAdaptedLesson> lessons) throws IllegalValueException {
         final List<Lesson> personLessons = new ArrayList<>();
         for (JsonAdaptedLesson lesson : lessons) {
             personLessons.add(lesson.toModelType());
         }
-        return new HashSet<>(personLessons);
+        return new ArrayList<>(personLessons);
     }
 
     private RemarkList getModelRemarkList(JsonAdaptedRemarkList remarkList) throws IllegalValueException {

--- a/src/test/java/tuteez/logic/parser/ParserUtilTest.java
+++ b/src/test/java/tuteez/logic/parser/ParserUtilTest.java
@@ -6,9 +6,11 @@ import static tuteez.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static tuteez.testutil.Assert.assertThrows;
 import static tuteez.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -261,10 +263,10 @@ public class ParserUtilTest {
 
     @Test
     public void parseLessons_collectionWithValidTags_returnsTagSet() throws Exception {
-        Set<Lesson> actualLessonSet = ParserUtil.parseLessons(Arrays.asList(VALID_LESSON, VALID_LESSON_2));
-        Set<Lesson> expectedLessonSet =
-                new HashSet<>(Arrays.asList(new Lesson(VALID_LESSON), new Lesson(VALID_LESSON_2)));
+        List<Lesson> actualLessonSet = ParserUtil.parseLessons(Arrays.asList(VALID_LESSON, VALID_LESSON_2));
+        List<Lesson> expectedLessonList =
+                new ArrayList<>(Arrays.asList(new Lesson(VALID_LESSON), new Lesson(VALID_LESSON_2)));
 
-        assertEquals(actualLessonSet, expectedLessonSet);
+        assertEquals(actualLessonSet, expectedLessonList);
     }
 }

--- a/src/test/java/tuteez/model/person/PersonTest.java
+++ b/src/test/java/tuteez/model/person/PersonTest.java
@@ -1,5 +1,10 @@
 package tuteez.model.person;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -10,6 +15,7 @@ import static tuteez.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static tuteez.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static tuteez.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static tuteez.logic.commands.CommandTestUtil.VALID_TELEGRAM_BOB;
+import tuteez.model.person.lesson.Lesson;
 import static tuteez.testutil.Assert.assertThrows;
 import static tuteez.testutil.TypicalPersons.ALICE;
 import static tuteez.testutil.TypicalPersons.BOB;
@@ -52,6 +58,43 @@ public class PersonTest {
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
         editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
         assertTrue(BOB.isSamePerson(editedBob));
+    }
+
+    @Test
+    public void nextLessonBasedOnCurrentTimeTest() {
+        LocalDateTime currentTime = LocalDateTime.now();
+
+        LocalDateTime lesson1DateTime = currentTime.plusDays(2).plusHours(10).plusMinutes(0);
+        LocalDateTime lesson1EndTime = lesson1DateTime.plusHours(1);
+
+        LocalDateTime lesson2DateTime = currentTime.plusHours(3).plusHours(15).plusMinutes(0);
+        LocalDateTime lesson2EndTime = lesson2DateTime.plusHours(1);
+
+        LocalDateTime lesson3DateTime = currentTime.plusHours(1).plusHours(3).plusMinutes(0);
+        LocalDateTime lesson3EndTime = lesson2DateTime.plusHours(1);
+
+        DateTimeFormatter dayFormatter = DateTimeFormatter.ofPattern("EEEE");
+        DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HHmm");
+
+        String lesson1Str = lesson1DateTime.format(dayFormatter) + " " +
+                lesson1DateTime.format(timeFormatter) + "-" +
+                lesson1EndTime.format(timeFormatter);
+
+        String lesson2Str = lesson2DateTime.format(dayFormatter) + " " +
+                lesson2DateTime.format(timeFormatter) + "-" +
+                lesson2EndTime.format(timeFormatter);
+
+        String lesson3Str = lesson3DateTime.format(dayFormatter) + " " +
+                lesson3DateTime.format(timeFormatter) + "-" +
+                lesson3EndTime.format(timeFormatter);
+
+        Lesson lesson3 = new Lesson(lesson3Str);
+
+        Person student = new PersonBuilder().withName(VALID_NAME_BOB)
+                .withPhone(VALID_PHONE_BOB)
+                .withLessons(lesson1Str, lesson2Str, lesson3Str).build();
+        assertEquals(student.nextLessonBasedOnCurrentTime(), lesson3);
+
     }
 
     @Test

--- a/src/test/java/tuteez/model/person/PersonTest.java
+++ b/src/test/java/tuteez/model/person/PersonTest.java
@@ -69,7 +69,7 @@ public class PersonTest {
         LocalDateTime lesson2EndTime = lesson2DateTime.plusHours(1);
 
         LocalDateTime lesson3DateTime = currentTime.plusHours(1).plusHours(3).plusMinutes(0);
-        LocalDateTime lesson3EndTime = lesson2DateTime.plusHours(1);
+        LocalDateTime lesson3EndTime = lesson3DateTime.plusHours(1);
 
         DateTimeFormatter dayFormatter = DateTimeFormatter.ofPattern("EEEE");
         DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HHmm");
@@ -77,20 +77,24 @@ public class PersonTest {
         String lesson1Str = lesson1DateTime.format(dayFormatter) + " "
                 + lesson1DateTime.format(timeFormatter) + "-"
                 + lesson1EndTime.format(timeFormatter);
+        lesson1Str = lesson1Str.toLowerCase();
 
         String lesson2Str = lesson2DateTime.format(dayFormatter) + " "
                 + lesson2DateTime.format(timeFormatter) + "-"
                 + lesson2EndTime.format(timeFormatter);
+        lesson2Str = lesson2Str.toLowerCase();
 
         String lesson3Str = lesson3DateTime.format(dayFormatter) + " "
                 + lesson3DateTime.format(timeFormatter) + "-"
                 + lesson3EndTime.format(timeFormatter);
+        lesson3Str = lesson3Str.toLowerCase();
 
         Lesson lesson3 = new Lesson(lesson3Str);
 
         Person student = new PersonBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB)
                 .withLessons(lesson1Str, lesson2Str, lesson3Str).build();
+
         assertEquals(student.nextLessonBasedOnCurrentTime(), lesson3);
 
     }

--- a/src/test/java/tuteez/model/person/PersonTest.java
+++ b/src/test/java/tuteez/model/person/PersonTest.java
@@ -1,10 +1,5 @@
 package tuteez.model.person;
 
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -15,13 +10,16 @@ import static tuteez.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static tuteez.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static tuteez.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static tuteez.logic.commands.CommandTestUtil.VALID_TELEGRAM_BOB;
-import tuteez.model.person.lesson.Lesson;
 import static tuteez.testutil.Assert.assertThrows;
 import static tuteez.testutil.TypicalPersons.ALICE;
 import static tuteez.testutil.TypicalPersons.BOB;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 import org.junit.jupiter.api.Test;
 
+import tuteez.model.person.lesson.Lesson;
 import tuteez.testutil.PersonBuilder;
 
 public class PersonTest {
@@ -76,17 +74,17 @@ public class PersonTest {
         DateTimeFormatter dayFormatter = DateTimeFormatter.ofPattern("EEEE");
         DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HHmm");
 
-        String lesson1Str = lesson1DateTime.format(dayFormatter) + " " +
-                lesson1DateTime.format(timeFormatter) + "-" +
-                lesson1EndTime.format(timeFormatter);
+        String lesson1Str = lesson1DateTime.format(dayFormatter) + " "
+                + lesson1DateTime.format(timeFormatter) + "-"
+                + lesson1EndTime.format(timeFormatter);
 
-        String lesson2Str = lesson2DateTime.format(dayFormatter) + " " +
-                lesson2DateTime.format(timeFormatter) + "-" +
-                lesson2EndTime.format(timeFormatter);
+        String lesson2Str = lesson2DateTime.format(dayFormatter) + " "
+                + lesson2DateTime.format(timeFormatter) + "-"
+                + lesson2EndTime.format(timeFormatter);
 
-        String lesson3Str = lesson3DateTime.format(dayFormatter) + " " +
-                lesson3DateTime.format(timeFormatter) + "-" +
-                lesson3EndTime.format(timeFormatter);
+        String lesson3Str = lesson3DateTime.format(dayFormatter) + " "
+                + lesson3DateTime.format(timeFormatter) + "-"
+                + lesson3EndTime.format(timeFormatter);
 
         Lesson lesson3 = new Lesson(lesson3Str);
 

--- a/src/test/java/tuteez/model/person/lesson/LessonTest.java
+++ b/src/test/java/tuteez/model/person/lesson/LessonTest.java
@@ -1,14 +1,14 @@
 package tuteez.model.person.lesson;
 
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static tuteez.model.person.lesson.Lesson.isValidLesson;
 import static tuteez.testutil.Assert.assertThrows;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/tuteez/model/person/lesson/LessonTest.java
+++ b/src/test/java/tuteez/model/person/lesson/LessonTest.java
@@ -146,7 +146,7 @@ public class LessonTest {
         assertEquals(durationTillSecondLesson, correctDuration);
     }
 
-    private static class LessonStub extends Lesson {
+    public static class LessonStub extends Lesson {
 
         /**
          * Constructs a {@code Lesson}.

--- a/src/test/java/tuteez/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/tuteez/testutil/EditPersonDescriptorBuilder.java
@@ -1,5 +1,6 @@
 package tuteez.testutil;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -102,8 +103,8 @@ public class EditPersonDescriptorBuilder {
      * that we are building.
      */
     public EditPersonDescriptorBuilder withLessons(String... lessons) {
-        Set<Lesson> lessonSet = Stream.of(lessons).map(Lesson::new).collect(Collectors.toSet());
-        descriptor.setLessons(lessonSet);
+        List<Lesson> lessonLst = Stream.of(lessons).map(Lesson::new).collect(Collectors.toList());
+        descriptor.setLessons(lessonLst);
         return this;
     }
 

--- a/src/test/java/tuteez/testutil/PersonBuilder.java
+++ b/src/test/java/tuteez/testutil/PersonBuilder.java
@@ -2,6 +2,7 @@ package tuteez.testutil;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import tuteez.model.person.Address;
@@ -32,7 +33,7 @@ public class PersonBuilder {
     private Address address;
     private TelegramUsername telegramUsername;
     private Set<Tag> tags;
-    private Set<Lesson> lessons;
+    private List<Lesson> lessons;
     private RemarkList remarkList;
 
     /**
@@ -45,7 +46,7 @@ public class PersonBuilder {
         address = new Address(DEFAULT_ADDRESS);
         telegramUsername = TelegramUsername.of(DEFAULT_TELEGRAM);
         tags = new HashSet<>();
-        lessons = new HashSet<>();
+        lessons = new ArrayList<>();
         remarkList = new RemarkList();
     }
 
@@ -60,7 +61,7 @@ public class PersonBuilder {
         telegramUsername = personToCopy.getTelegramUsername();
         tags = new HashSet<>(personToCopy.getTags());
         remarkList = new RemarkList(new ArrayList<>(personToCopy.getRemarkList().getRemarks()));
-        lessons = new HashSet<>(personToCopy.getLessons());
+        lessons = new ArrayList<>(personToCopy.getLessons());
     }
 
     /**
@@ -83,7 +84,7 @@ public class PersonBuilder {
      * Parses the {@code lessons} into a {@code Set<Lesson>} and set it to the {@code Person} that we are building.
      */
     public PersonBuilder withLessons(String ... lessons) {
-        this.lessons = SampleDataUtil.getLessonSet(lessons);
+        this.lessons = SampleDataUtil.getLessonLst(lessons);
         return this;
     }
 

--- a/src/test/java/tuteez/testutil/PersonUtil.java
+++ b/src/test/java/tuteez/testutil/PersonUtil.java
@@ -8,6 +8,7 @@ import static tuteez.logic.parser.CliSyntax.PREFIX_PHONE;
 import static tuteez.logic.parser.CliSyntax.PREFIX_TAG;
 import static tuteez.logic.parser.CliSyntax.PREFIX_TELEGRAM;
 
+import java.util.List;
 import java.util.Set;
 
 import tuteez.logic.commands.AddCommand;
@@ -67,7 +68,7 @@ public class PersonUtil {
             }
         }
         if (descriptor.getLessons().isPresent()) {
-            Set<Lesson> lessons = descriptor.getLessons().get();
+            List<Lesson> lessons = descriptor.getLessons().get();
             if (lessons.isEmpty()) {
                 sb.append(PREFIX_LESSON);
             } else {


### PR DESCRIPTION
## What is this PR for? 
- Information on student's next lesson based on current time should be displayed on the left side as this is relevant info tutors can use at a glance.

## What does this PR do? 
- Implemented a method to find and return the next scheduled lesson for a student based on the current date and time.
- The method identifies the lesson with the shortest time until its start, allowing for better scheduling insights.
- Returns null if no upcoming lessons are scheduled.

### Note: 
- When a lesson is ongoing duration till lesson is considered as 0 days, 0 hours, 0 minutes 
- If the current time coincides with a lessons day, start and end time it is considered as ongoing. 
- For example the following lesson is ongoing: 
   * Current Time: Monday 1000
   * Lesson Time: Monday 0800-1000
