### PR TITLE
Bug Fix: Add clashing lessons for the same student

### DIFF
--- a/src/main/java/tuteez/logic/commands/AddCommand.java
+++ b/src/main/java/tuteez/logic/commands/AddCommand.java
@@ -55,6 +55,7 @@ public class AddCommand extends Command {
     public static final String MESSAGE_SUCCESS = "New student added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This student already exists in the address book";
     public static final String MESSAGE_CLASHING_LESSON = "This time slot clashes with the following lessons: \n";
+    public static final String MESSAGE_NEW_LESSONS_CLASH = "Adding clashing lessons is not allowed";
 
     private final Person toAdd;
     private final Logger logger = LogsCenter.getLogger(AddCommand.class);
@@ -76,6 +77,10 @@ public class AddCommand extends Command {
         }
 
         Set<Lesson> lessonSet = toAdd.getLessons();
+        if (Lesson.containsClashes(lessonSet)) {
+            throw new CommandException(MESSAGE_NEW_LESSONS_CLASH);
+        }
+
         Map<Person, ArrayList<Lesson>> resultMap = new HashMap<>();
         for (Lesson lesson: lessonSet) {
             assert lesson != null;

--- a/src/main/java/tuteez/model/person/lesson/Lesson.java
+++ b/src/main/java/tuteez/model/person/lesson/Lesson.java
@@ -5,10 +5,13 @@ import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON;
 
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 
 /**
@@ -103,7 +106,6 @@ public class Lesson {
         return false;
     }
 
-
     /**
      * Validates if the given lesson string is valid.
      * The lesson should consist of a day and a time range separated by a space.
@@ -149,6 +151,32 @@ public class Lesson {
                  || firstLs.startTime.equals(secondLs.endTime);
         return !(completelyBefore || completelyAfter);
     }
+
+    /**
+     * Checks if any two lessons in the provided set clash with each other.
+     *
+     * <p>This method iterates through lessons in and determines
+     * if there is a timing conflict between any two lessons.</p>
+     *
+     * @param lessons A set of {@code Lesson} objects to check for clashes.
+     * @return {@code true} if any two lessons in the set have a timing conflict,
+     *         {@code false} otherwise.
+     */
+    public static boolean containsClashes(Set<Lesson> lessons) {
+        List<Lesson> lessonList = new ArrayList<>(lessons); // Convert to list for easy indexing
+
+        for (int i = 0; i < lessonList.size(); i++) {
+            Lesson lesson1 = lessonList.get(i);
+            for (int j = i + 1; j < lessonList.size(); j++) {
+                Lesson lesson2 = lessonList.get(j);
+                if (isClashingWithOtherLesson(lesson1, lesson2)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
 
     /**
      * Returns the day on which this lesson occurs.


### PR DESCRIPTION
## What is this PR for? 

Fix a bug where when adding a student, users can allocate clashing lessons to them 

## What does this PR do? 

Before checking against all existing lessons, it first checks whether the lessons we intend to add clash with one another 