### PR TITLE
Branch update javadocs to list

### DIFF
--- a/src/main/java/tuteez/logic/commands/EditCommand.java
+++ b/src/main/java/tuteez/logic/commands/EditCommand.java
@@ -300,7 +300,7 @@ public class EditCommand extends Command {
         }
 
         /**
-         * Returns an unmodifiable lesson set, which throws {@code UnsupportedOperationException}
+         * Returns an unmodifiable lesson list, which throws {@code UnsupportedOperationException}
          * if modification is attempted.
          * Returns {@code Optional#empty()} if {@code lessons} is null.
          */

--- a/src/main/java/tuteez/model/person/Person.java
+++ b/src/main/java/tuteez/model/person/Person.java
@@ -102,7 +102,7 @@ public class Person {
     }
 
     /**
-     * Returns an immutable lesson set, which throws {@code UnsupportedOperationException}
+     * Returns an immutable lesson list, which throws {@code UnsupportedOperationException}
      * if modification is attempted.
      */
     public List<Lesson> getLessons() {

--- a/src/main/java/tuteez/model/person/lesson/Lesson.java
+++ b/src/main/java/tuteez/model/person/lesson/Lesson.java
@@ -122,13 +122,13 @@ public class Lesson {
     }
 
     /**
-     * Checks if any two lessons in the provided set clash with each other.
+     * Checks if any two lessons in the provided list clash with each other.
      *
      * <p>This method iterates through lessons in and determines
      * if there is a timing conflict between any two lessons.</p>
      *
-     * @param lessons A set of {@code Lesson} objects to check for clashes.
-     * @return {@code true} if any two lessons in the set have a timing conflict,
+     * @param lessons A list of {@code Lesson} objects to check for lesson clashes within the given list.
+     * @return {@code true} if any two lessons in the list have a timing conflict,
      *         {@code false} otherwise.
      */
     public static boolean containsClashes(List<Lesson> lessons) {

--- a/src/main/java/tuteez/model/person/lesson/LessonManager.java
+++ b/src/main/java/tuteez/model/person/lesson/LessonManager.java
@@ -75,7 +75,8 @@ public class LessonManager {
      * <p>Note: Consecutive lessons (e.g., timings 1900-2000 & 2000-2100) do not clash
      * as they do not overlap in time.</p>
      *
-     * @param studentList The {@code UniquePersonList} of students whose lessons are to be checked for potential clashes.
+     * @param studentList The {@code UniquePersonList} of students whose lessons are to be checked for potential
+     *                    clashes.
      * @param lesson The lesson to check for time conflicts.
      * @return A map where each entry consists of a {@code Person} whose lessons clash with the specified lesson,
      *         and an {@code ArrayList} of the clashing lessons for that student.

--- a/src/main/java/tuteez/model/person/lesson/LessonManager.java
+++ b/src/main/java/tuteez/model/person/lesson/LessonManager.java
@@ -13,7 +13,7 @@ import tuteez.model.person.Person;
 import tuteez.model.person.UniquePersonList;
 
 /**
- * A container for all Lesson instances
+ * A container for all existing Lesson instances
  * Provides:
  *  1. Methods to add and delete
  *  2. Check for clashing lessons
@@ -75,7 +75,7 @@ public class LessonManager {
      * <p>Note: Consecutive lessons (e.g., timings 1900-2000 & 2000-2100) do not clash
      * as they do not overlap in time.</p>
      *
-     * @param studentList The list of students whose lessons are to be checked for potential clashes.
+     * @param studentList The {@code UniquePersonList} of students whose lessons are to be checked for potential clashes.
      * @param lesson The lesson to check for time conflicts.
      * @return A map where each entry consists of a {@code Person} whose lessons clash with the specified lesson,
      *         and an {@code ArrayList} of the clashing lessons for that student.

--- a/src/main/java/tuteez/model/util/SampleDataUtil.java
+++ b/src/main/java/tuteez/model/util/SampleDataUtil.java
@@ -61,7 +61,7 @@ public class SampleDataUtil {
     }
 
     /**
-     * Returns a Lesson set containing the list of strings given.
+     * Returns a Lesson list containing the list of strings given.
      */
     public static List<Lesson> getLessonLst(String... strings) {
         return Arrays.stream(strings)


### PR DESCRIPTION
Resolve #174 

- Update JavaDocs in relevant classes to adhere to new implementation of how students store lessons using a `List<Lesson>` instead of `Set<Lesson>`