### PR TITLE
Change tags to allow spaces

### DIFF
--- a/src/main/java/tuteez/model/tag/Tag.java
+++ b/src/main/java/tuteez/model/tag/Tag.java
@@ -9,8 +9,8 @@ import static tuteez.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric and can include spaces";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum} ]+";
 
     public final String tagName;
 

--- a/src/test/java/tuteez/model/tag/TagTest.java
+++ b/src/test/java/tuteez/model/tag/TagTest.java
@@ -1,5 +1,7 @@
 package tuteez.model.tag;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static tuteez.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -21,6 +23,17 @@ public class TagTest {
     public void isValidTagName() {
         // null tag name
         assertThrows(NullPointerException.class, () -> Tag.isValidTagName(null));
+    }
+
+    @Test
+    public void isValidTagName_validInputs_returnTrue() {
+        assertTrue(Tag.isValidTagName("Secondary 4 Math"));
+        assertTrue(Tag.isValidTagName("Science123"));
+    }
+    @Test
+    public void isValidTagName_invalidInputs_returnFalse() {
+        assertFalse(Tag.isValidTagName("Secondary 4 Math!"));
+        assertFalse(Tag.isValidTagName("(Secondary 1 Science)+"));
     }
 
 }


### PR DESCRIPTION
Resolve #176 

### What is this PR for?
Currently Tags do not allow spaces. This means that when tutors cannot add tags like "Seconday 4 Math" or "JC Chemistry" and will have to use multiple tags to achieve the same effect.

### What does this PR do?
- Edit the regex in the Tag class to allow empty spaces
- Add test cases for isValidTagName function to check the regex for both valid and invalid tags