### PR TITLE
Potential improvement: Make add command errors more specific

### DIFF
--- a/src/main/java/tuteez/logic/Messages.java
+++ b/src/main/java/tuteez/logic/Messages.java
@@ -20,7 +20,10 @@ public class Messages {
     public static final String MESSAGE_INVALID_PERSON_INDEX_FORMAT =
             "Person index must be a single, positive number (eg, '1', '2', '3').";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
-
+    public static final String MESSAGE_MISSING_PERSON_NAME =
+            "Person name is required but missing. Please provide the name of the person using n/.";
+    public static final String MESSAGE_MISSING_PHONE =
+            "Person phone number is required but missing. Please provide the phone of the person using p/.";
     public static final String MESSAGE_REMARK_MULTIPLE_OPERATIONS =
             "Cannot add and delete remarks simultaneously. Please use only one operation at a time.";
     public static final String MESSAGE_REMARK_MISSING_COMMAND_TYPE =

--- a/src/main/java/tuteez/logic/parser/AddCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/AddCommandParser.java
@@ -1,6 +1,8 @@
 package tuteez.logic.parser;
 
 import static tuteez.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static tuteez.logic.Messages.MESSAGE_MISSING_PERSON_NAME;
+import static tuteez.logic.Messages.MESSAGE_MISSING_PHONE;
 import static tuteez.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static tuteez.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON;
@@ -38,16 +40,14 @@ public class AddCommandParser implements Parser<AddCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                         PREFIX_TELEGRAM, PREFIX_TAG, PREFIX_LESSON);
-
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE)
-                || !argMultimap.getPreamble().isEmpty()) {
+        if (!argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
-
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                 PREFIX_TELEGRAM);
-        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-        Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
+        Phone phone = parsePhoneFromArgMultiMap(argMultimap);
+        Name name = parseNameFromArgMultiMap(argMultimap);
+        verifyRequiredFields(name, phone);
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).orElse(null));
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).orElse(null));
         TelegramUsername telegramUsername = ParserUtil.parseTelegramUsername(
@@ -67,6 +67,52 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+    /**
+     * Parses the phone number from the given ArgumentMultimap.
+     *
+     * @param argMultimap the ArgumentMultimap containing the parsed arguments
+     * @return the parsed Phone object or null if the phone prefix is not present
+     * @throws ParseException if the phone number is invalid
+     */
+    private Phone parsePhoneFromArgMultiMap(ArgumentMultimap argMultimap) throws ParseException {
+        if (arePrefixesPresent(argMultimap, PREFIX_PHONE)) {
+            return ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Parses the name from the given ArgumentMultimap.
+     *
+     * @param argMultimap the ArgumentMultimap containing the parsed arguments
+     * @return the parsed Name object or null if the name prefix is not present
+     * @throws ParseException if the name is invalid
+     */
+    private Name parseNameFromArgMultiMap(ArgumentMultimap argMultimap) throws ParseException {
+        if (arePrefixesPresent(argMultimap, PREFIX_NAME)) {
+            return ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Verifies that the required fields (name and phone) are present and valid.
+     *
+     * @param name the parsed Name object
+     * @param phone the parsed Phone object
+     * @throws ParseException if any of the required fields are missing
+     */
+    private void verifyRequiredFields(Name name, Phone phone) throws ParseException {
+        if (name == null) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_PERSON_NAME));
+        }
+        if (phone == null) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_PHONE));
+        }
     }
 
 }

--- a/src/main/java/tuteez/logic/parser/AddCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/AddCommandParser.java
@@ -107,6 +107,9 @@ public class AddCommandParser implements Parser<AddCommand> {
      * @throws ParseException if any of the required fields are missing
      */
     private void verifyRequiredFields(Name name, Phone phone) throws ParseException {
+        if (name == null && phone == null) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+        }
         if (name == null) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_PERSON_NAME));
         }

--- a/src/test/java/tuteez/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/tuteez/logic/parser/AddCommandParserTest.java
@@ -178,18 +178,21 @@ public class AddCommandParserTest {
         String expectedMissingNameMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_PERSON_NAME);
         String expectedMissingPhoneMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_PHONE);
 
+        // Boundary Value Test: Empty input
+        assertParseFailure(parser, "   ", expectedMessage);
+
         // contains preamble
         assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
                 expectedMessage);
 
-        // missing phone prefix
+        // Missing phone prefix
         assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
                 expectedMissingPhoneMessage);
 
-        // missing name prefix
+        // Missing name prefix
         assertParseFailure(parser, PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB, expectedMissingNameMessage);
 
-        // all prefixes missing
+        // Boundary Value Test: All prefixes are missing
         assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_EMAIL_BOB + VALID_ADDRESS_BOB,
                 expectedMessage);
     }

--- a/src/test/java/tuteez/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/tuteez/logic/parser/AddCommandParserTest.java
@@ -1,6 +1,8 @@
 package tuteez.logic.parser;
 
 import static tuteez.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static tuteez.logic.Messages.MESSAGE_MISSING_PERSON_NAME;
+import static tuteez.logic.Messages.MESSAGE_MISSING_PHONE;
 import static tuteez.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static tuteez.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static tuteez.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
@@ -173,14 +175,19 @@ public class AddCommandParserTest {
     @Test
     public void parse_compulsoryFieldMissing_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
+        String expectedMissingNameMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_PERSON_NAME);
+        String expectedMissingPhoneMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_PHONE);
 
-        // missing name prefix
+        // contains preamble
         assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
                 expectedMessage);
 
         // missing phone prefix
         assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
+                expectedMissingPhoneMessage);
+
+        // missing name prefix
+        assertParseFailure(parser, PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB, expectedMissingNameMessage);
 
         // all prefixes missing
         assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_EMAIL_BOB + VALID_ADDRESS_BOB,


### PR DESCRIPTION
Resolve #160 
### What is this PR for?
The current implementation of the `add` command provides overly general error messages when compulsory fields such as the name and phone number are missing. This PR aims to enhance user experience by providing specific error messages based on the input given by the user.

### Expected Behavior:
- When a user enters `add n/john`, our app should specifically indicate that the phone number field is missing.
- When a user enters `add p/90916126`, our app should indicate that the name field is missing.
- If a user inputs an invalid name like `add n/john$%&`, the error message should specify that the name is invalid rather than indicating a missing phone number.
- Similarly, if a user inputs an invalid phone number like `add p/1`, the error message should specify that the phone number is invalid rather than indicating a missing name.

## What does this PR do?
Implement the parser check for compulsory fields in the following order:
1. **Initial Preamble Check**: 
   - The parser first checks for any preambles before validating the fields. If the user inputs `add something`, the system will output a generic error message indicating invalid command format for add. This is the current error message we have for add.
2. **Duplicate Prefix Check**: 
   - The parser checks for any duplicate prefixes and outputs an error message if duplicates are found.
 
3. **Field-Specific Validations**: 
- The parser checks for the presence and validity of the `n/` (name) and `p/` (phone) prefixes and outputs specific error messages accordingly:
  - If only the name is provided (e.g., `add n/john`), but the phone is missing, the error message will specify the missing phone number.
  - If only the phone is provided (e.g., `add p/90916126`), but the name is missing, the error message will specify the missing name.
  - If the name is invalid (e.g., `add n/john$%^`), the error message will indicate that the name input is incorrect instead of indicating a missing phone field.
  - If the phone number is invalid (e.g, `add p/1`), the error message will indicate that the phone number is incorrect instead of indicating a missing name field.