### PR TITLE
Improve edit error messages

### DIFF
--- a/src/main/java/tuteez/logic/Messages.java
+++ b/src/main/java/tuteez/logic/Messages.java
@@ -14,7 +14,6 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_NEED_TO_PROVIDE_INDEX = "You must provide an index";
 
     public static final String MESSAGE_MISSING_PERSON_INDEX =
             "Person index is required but missing. Please provide the index of the person as displayed in the list.";

--- a/src/main/java/tuteez/logic/Messages.java
+++ b/src/main/java/tuteez/logic/Messages.java
@@ -14,6 +14,7 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
+    public static final String MESSAGE_NEED_TO_PROVIDE_INDEX = "You must provide an index";
 
     public static final String MESSAGE_MISSING_PERSON_INDEX =
             "Person index is required but missing. Please provide the index of the person as displayed in the list.";

--- a/src/main/java/tuteez/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/tuteez/logic/parser/ArgumentMultimap.java
@@ -75,4 +75,19 @@ public class ArgumentMultimap {
             throw new ParseException(Messages.getErrorMessageForDuplicatePrefixes(duplicatedPrefixes));
         }
     }
+
+    /**
+     * Checks if the argument map contains any prefixes (indicating multiple keys).
+     *
+     * <p>This method checks whether the {@code argMultimap} has more than one entry.
+     * There is always a single entry in {@code argMultimap} where the key is an empty
+     * string and the value is an empty array, so a size greater than 1 implies the presence
+     * of other prefixes.</p>
+     *
+     * @return {@code true} if {@code argMultimap} contains more than one entry, indicating
+     *         the presence of prefixes; {@code false} otherwise.
+     */
+    public boolean hasPrefixes() {
+        return argMultimap.size() > 1;
+    }
 }

--- a/src/main/java/tuteez/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/tuteez/logic/parser/ArgumentMultimap.java
@@ -87,7 +87,7 @@ public class ArgumentMultimap {
      * @return {@code true} if {@code argMultimap} contains more than one entry, indicating
      *         the presence of prefixes; {@code false} otherwise.
      */
-    public boolean hasPrefixes() {
+    public boolean verifyHasPrefixes() {
         return argMultimap.size() > 1;
     }
 }

--- a/src/main/java/tuteez/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/tuteez/logic/parser/ArgumentMultimap.java
@@ -87,7 +87,7 @@ public class ArgumentMultimap {
      * @return {@code true} if {@code argMultimap} contains more than one entry, indicating
      *         the presence of prefixes; {@code false} otherwise.
      */
-    public boolean verifyHasPrefixes() {
+    public boolean hasPrefixes() {
         return argMultimap.size() > 1;
     }
 }

--- a/src/main/java/tuteez/logic/parser/EditCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/EditCommandParser.java
@@ -2,6 +2,7 @@ package tuteez.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static tuteez.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static tuteez.logic.Messages.MESSAGE_NEED_TO_PROVIDE_INDEX;
 import static tuteez.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static tuteez.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON;
@@ -47,6 +48,10 @@ public class EditCommandParser implements Parser<EditCommand> {
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
+            if (argMultimap.getPreamble().isEmpty() && argMultimap.hasPrefixes()) {
+                throw new ParseException(MESSAGE_NEED_TO_PROVIDE_INDEX + " for the edit command");
+            }
+
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }
 

--- a/src/main/java/tuteez/logic/parser/EditCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/EditCommandParser.java
@@ -48,7 +48,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            if (argMultimap.getPreamble().isEmpty() && argMultimap.verifyHasPrefixes()) {
+            if (argMultimap.getPreamble().isEmpty() && argMultimap.hasPrefixes()) {
                 throw new ParseException(MESSAGE_MISSING_PERSON_INDEX);
             }
 

--- a/src/main/java/tuteez/logic/parser/EditCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/EditCommandParser.java
@@ -2,7 +2,7 @@ package tuteez.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static tuteez.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static tuteez.logic.Messages.MESSAGE_NEED_TO_PROVIDE_INDEX;
+import static tuteez.logic.Messages.MESSAGE_MISSING_PERSON_INDEX;
 import static tuteez.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static tuteez.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON;
@@ -48,8 +48,8 @@ public class EditCommandParser implements Parser<EditCommand> {
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            if (argMultimap.getPreamble().isEmpty() && argMultimap.hasPrefixes()) {
-                throw new ParseException(MESSAGE_NEED_TO_PROVIDE_INDEX + " for the edit command");
+            if (argMultimap.getPreamble().isEmpty() && argMultimap.verifyHasPrefixes()) {
+                throw new ParseException(MESSAGE_MISSING_PERSON_INDEX);
             }
 
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);

--- a/src/test/java/tuteez/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/tuteez/logic/parser/EditCommandParserTest.java
@@ -82,8 +82,8 @@ public class EditCommandParserTest {
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
 
         // No index but valid command otherwise
-        assertParseFailure(parser, " t/math", Messages.MESSAGE_NEED_TO_PROVIDE_INDEX
-                + " for the edit command");
+        assertParseFailure(parser, " t/math", Messages.MESSAGE_MISSING_PERSON_INDEX);
+
     }
 
     @Test

--- a/src/test/java/tuteez/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/tuteez/logic/parser/EditCommandParserTest.java
@@ -80,6 +80,10 @@ public class EditCommandParserTest {
 
         // no index and no field specified
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+
+        // No index but valid command otherwise
+        assertParseFailure(parser, " t/math", Messages.MESSAGE_NEED_TO_PROVIDE_INDEX
+                + " for the edit command");
     }
 
     @Test


### PR DESCRIPTION
## What is this PR for? 
- Provides more specific error messages for edit command 

## What does this PR do? 
- When user types `edit` it shows a long error message for invalid command format 
- If use does `edit t/math` for example where everything is correct except it is missing an index, the error message tells user they need to have an index for edit 