### PR TITLE
Remove the ability to add/edit/remove `Lesson`s via `EditCommand`

### DIFF
--- a/src/main/java/tuteez/logic/commands/EditCommand.java
+++ b/src/main/java/tuteez/logic/commands/EditCommand.java
@@ -55,8 +55,8 @@ public class EditCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johnd@gmail.com\n"
-            + "Note: You can leave the optional parameters specified in 'add' blank "
-            + "in order to delete the existing values.\n"
+            + "Note: To delete existing values of an optional parameter in the 'add' command, "
+            + "enter its prefix with an empty value. (eg. edit 1 e/ will delete the email) \n"
             + "Note: Lessons can be added or removed via the 'addlesson' or 'deletelesson' commands respectively.";
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";

--- a/src/main/java/tuteez/logic/commands/EditCommand.java
+++ b/src/main/java/tuteez/logic/commands/EditCommand.java
@@ -62,7 +62,6 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
-    public static final String MESSAGE_CLASHING_LESSON = "This time slot clashes with the following lessons:";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;

--- a/src/main/java/tuteez/logic/commands/EditCommand.java
+++ b/src/main/java/tuteez/logic/commands/EditCommand.java
@@ -3,7 +3,6 @@ package tuteez.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static tuteez.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static tuteez.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON;
 import static tuteez.logic.parser.CliSyntax.PREFIX_NAME;
 import static tuteez.logic.parser.CliSyntax.PREFIX_PHONE;
 import static tuteez.logic.parser.CliSyntax.PREFIX_TAG;
@@ -12,10 +11,8 @@ import static tuteez.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;

--- a/src/main/java/tuteez/logic/parser/EditCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/EditCommandParser.java
@@ -40,7 +40,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-                        PREFIX_TELEGRAM, PREFIX_TAG, PREFIX_LESSON);
+                        PREFIX_TELEGRAM, PREFIX_TAG);
 
         Index index;
 
@@ -74,7 +74,6 @@ public class EditCommandParser implements Parser<EditCommand> {
             setEditedTelegramUsername(editPersonDescriptor, telegramUsername);
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
-        parseLessonsForEdit(argMultimap.getAllValues(PREFIX_LESSON)).ifPresent(editPersonDescriptor::setLessons);
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
@@ -121,21 +120,6 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
         return Optional.of(ParserUtil.parseTags(tagSet));
-    }
-
-    /**
-     * Parses {@code Collection<String> lessons} into a {@code Set<Lesson>} if {@code lessons} is non-empty.
-     * If {@code lessons} contain only one element which is an empty string, it will be parsed into a
-     * {@code Set<Lesson>} containing zero lessons.
-     */
-    private Optional<List<Lesson>> parseLessonsForEdit(Collection<String> lessons) throws ParseException {
-        assert lessons != null;
-
-        if (lessons.isEmpty()) {
-            return Optional.empty();
-        }
-        Collection<String> lessonLst = lessons.size() == 1 && lessons.contains("") ? Collections.emptySet() : lessons;
-        return Optional.of(ParserUtil.parseLessons(lessonLst));
     }
 
 }

--- a/src/main/java/tuteez/logic/parser/EditCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/EditCommandParser.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 import static tuteez.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static tuteez.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static tuteez.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON;
 import static tuteez.logic.parser.CliSyntax.PREFIX_NAME;
 import static tuteez.logic.parser.CliSyntax.PREFIX_PHONE;
 import static tuteez.logic.parser.CliSyntax.PREFIX_TAG;
@@ -12,7 +11,6 @@ import static tuteez.logic.parser.CliSyntax.PREFIX_TELEGRAM;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -23,7 +21,6 @@ import tuteez.logic.parser.exceptions.ParseException;
 import tuteez.model.person.Address;
 import tuteez.model.person.Email;
 import tuteez.model.person.TelegramUsername;
-import tuteez.model.person.lesson.Lesson;
 import tuteez.model.tag.Tag;
 
 /**

--- a/src/test/java/tuteez/logic/commands/CommandTestUtil.java
+++ b/src/test/java/tuteez/logic/commands/CommandTestUtil.java
@@ -82,7 +82,7 @@ public class CommandTestUtil {
         DESC_BOB = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
                 .withTelegram(VALID_TELEGRAM_BOB)
-                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).withLessons(VALID_LESSON_DAY_AND_TME).build();
+                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
     }
 
     /**

--- a/src/test/java/tuteez/logic/commands/EditCommandTest.java
+++ b/src/test/java/tuteez/logic/commands/EditCommandTest.java
@@ -124,50 +124,6 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_lessonClashesWithExistingLesson_noClashOccurs() {
-        Person secondPersonInList = model.getAddressBook().getPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
-        EditPersonDescriptor secondPersonDescriptor = new EditPersonDescriptorBuilder(secondPersonInList)
-                .withLessons("friday 1830-2000").build();
-        EditCommand firstEdit = new EditCommand(INDEX_SECOND_PERSON, secondPersonDescriptor);
-        assertDoesNotThrow(() -> firstEdit.execute(model));
-
-        Person firstPersonInList = model.getAddressBook().getPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        EditPersonDescriptor firstPersonDescriptor = new EditPersonDescriptorBuilder(firstPersonInList)
-                .withLessons("friday 1730-1830").build();
-        EditCommand secondEdit = new EditCommand(INDEX_FIRST_PERSON, firstPersonDescriptor);
-        assertDoesNotThrow(() -> secondEdit.execute(model));
-    }
-
-    @Test
-    public void execute_lessonClashesWithExistingLesson_clashOccurs() {
-        Person secondPersonInList = model.getAddressBook().getPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
-        EditPersonDescriptor secondPersonDescriptor = new EditPersonDescriptorBuilder(secondPersonInList)
-                .withLessons("friday 1800-2000").build();
-        EditCommand firstEdit = new EditCommand(INDEX_SECOND_PERSON, secondPersonDescriptor);
-        assertDoesNotThrow(() -> firstEdit.execute(model));
-
-        Person firstPersonInList = model.getAddressBook().getPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        EditPersonDescriptor firstPersonDescriptor = new EditPersonDescriptorBuilder(firstPersonInList)
-                .withLessons("friday 1730-1830").build();
-        EditCommand secondEdit = new EditCommand(INDEX_FIRST_PERSON, firstPersonDescriptor);
-        assertThrows(CommandException.class, () -> secondEdit.execute(model));
-    }
-
-    @Test
-    public void execute_lessonClashesWithSameStudentsExistingLesson_noClashOccurs() {
-        Person firstPersonInList = model.getAddressBook().getPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        EditPersonDescriptor firstDescriptor = new EditPersonDescriptorBuilder(firstPersonInList)
-                .withLessons("friday 1800-2000").build();
-        EditCommand firstEdit = new EditCommand(INDEX_FIRST_PERSON, firstDescriptor);
-        assertDoesNotThrow(() -> firstEdit.execute(model));
-
-        EditPersonDescriptor secondDescriptor = new EditPersonDescriptorBuilder(firstPersonInList)
-                .withLessons("friday 1730-1830").build();
-        EditCommand secondEdit = new EditCommand(INDEX_FIRST_PERSON, secondDescriptor);
-        assertDoesNotThrow(() -> secondEdit.execute(model));
-    }
-
-    @Test
     public void execute_invalidPersonIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build();
@@ -191,6 +147,31 @@ public class EditCommandTest {
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_retainsOriginalLessons_success() {
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+        Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
+
+        PersonBuilder personInList = new PersonBuilder(lastPerson);
+        Person editedPerson = personInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
+                .withTags(VALID_TAG_HUSBAND).build();
+
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
+                .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_HUSBAND).build();
+        EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS,
+                Messages.format(editedPerson));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(lastPerson, editedPerson);
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+
+        // Verify that lessons remain unchanged
+        assertEquals(lastPerson.getLessons(), editedPerson.getLessons());
     }
 
     @Test

--- a/src/test/java/tuteez/logic/commands/EditCommandTest.java
+++ b/src/test/java/tuteez/logic/commands/EditCommandTest.java
@@ -1,9 +1,7 @@
 package tuteez.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static tuteez.logic.commands.CommandTestUtil.DESC_AMY;
 import static tuteez.logic.commands.CommandTestUtil.DESC_BOB;
@@ -22,7 +20,6 @@ import org.junit.jupiter.api.Test;
 import tuteez.commons.core.index.Index;
 import tuteez.logic.Messages;
 import tuteez.logic.commands.EditCommand.EditPersonDescriptor;
-import tuteez.logic.commands.exceptions.CommandException;
 import tuteez.model.AddressBook;
 import tuteez.model.Model;
 import tuteez.model.ModelManager;

--- a/src/test/java/tuteez/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/tuteez/logic/commands/EditPersonDescriptorTest.java
@@ -10,6 +10,7 @@ import static tuteez.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static tuteez.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static tuteez.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static tuteez.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static tuteez.logic.commands.CommandTestUtil.VALID_TELEGRAM_BOB;
 
 import org.junit.jupiter.api.Test;
 
@@ -54,6 +55,10 @@ public class EditPersonDescriptorTest {
 
         // different tags -> returns false
         editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withTags(VALID_TAG_HUSBAND).build();
+        assertFalse(DESC_AMY.equals(editedAmy));
+
+        // different telegram username -> returns false
+        editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withTelegram(VALID_TELEGRAM_BOB).build();
         assertFalse(DESC_AMY.equals(editedAmy));
     }
 

--- a/src/test/java/tuteez/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/tuteez/logic/commands/EditPersonDescriptorTest.java
@@ -66,8 +66,7 @@ public class EditPersonDescriptorTest {
                 + editPersonDescriptor.getEmail().orElse(null) + ", address="
                 + editPersonDescriptor.getAddress().orElse(null) + ", telegramUsername="
                 + editPersonDescriptor.getTelegramUsername().orElse(null) + ", tags="
-                + editPersonDescriptor.getTags().orElse(null) + ", lessons="
-                + editPersonDescriptor.getLessons().orElse(null) + "}";
+                + editPersonDescriptor.getTags().orElse(null) + "}";
 
         assertEquals(expected, editPersonDescriptor.toString());
     }

--- a/src/test/java/tuteez/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/tuteez/logic/parser/EditCommandParserTest.java
@@ -10,7 +10,6 @@ import static tuteez.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static tuteez.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static tuteez.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static tuteez.logic.commands.CommandTestUtil.INVALID_TELEGRAM_DESC;
-import static tuteez.logic.commands.CommandTestUtil.LESSON_DESC_MON;
 import static tuteez.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static tuteez.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static tuteez.logic.commands.CommandTestUtil.PHONE_DESC_BOB;

--- a/src/test/java/tuteez/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/tuteez/logic/parser/EditCommandParserTest.java
@@ -6,7 +6,6 @@ import static tuteez.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static tuteez.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static tuteez.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static tuteez.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
-import static tuteez.logic.commands.CommandTestUtil.INVALID_LESSON_DESC;
 import static tuteez.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static tuteez.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static tuteez.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
@@ -20,7 +19,6 @@ import static tuteez.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
 import static tuteez.logic.commands.CommandTestUtil.TELEGRAM_DESC_AMY;
 import static tuteez.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static tuteez.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
-import static tuteez.logic.commands.CommandTestUtil.VALID_LESSON_DAY_AND_TME;
 import static tuteez.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static tuteez.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static tuteez.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
@@ -29,7 +27,6 @@ import static tuteez.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static tuteez.logic.commands.CommandTestUtil.VALID_TELEGRAM_AMY;
 import static tuteez.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static tuteez.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON;
 import static tuteez.logic.parser.CliSyntax.PREFIX_PHONE;
 import static tuteez.logic.parser.CliSyntax.PREFIX_TAG;
 import static tuteez.logic.parser.CliSyntax.PREFIX_TELEGRAM;
@@ -49,15 +46,12 @@ import tuteez.model.person.Email;
 import tuteez.model.person.Name;
 import tuteez.model.person.Phone;
 import tuteez.model.person.TelegramUsername;
-import tuteez.model.person.lesson.Lesson;
 import tuteez.model.tag.Tag;
 import tuteez.testutil.EditPersonDescriptorBuilder;
 
 public class EditCommandParserTest {
 
     private static final String TAG_EMPTY = " " + PREFIX_TAG;
-
-    private static final String LESSON_EMPTY = " " + PREFIX_LESSON;
 
     private static final String TELEGRAM_EMPTY = " " + PREFIX_TELEGRAM;
 
@@ -116,11 +110,6 @@ public class EditCommandParserTest {
         assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
 
-        // while parsing {@code PREFIX_LESSON} alone will reset the tags of the {@code Person} being edited,
-        // parsing it together with a valid tag will result in error
-        assertParseFailure(parser, "1" + LESSON_DESC_MON + LESSON_EMPTY, Lesson.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + LESSON_EMPTY + LESSON_DESC_MON, Lesson.MESSAGE_CONSTRAINTS);
-
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_ADDRESS_AMY + VALID_PHONE_AMY,
                 Name.MESSAGE_CONSTRAINTS);
@@ -131,12 +120,12 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_SECOND_PERSON;
         String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + TAG_DESC_HUSBAND
                 + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NAME_DESC_AMY + TELEGRAM_DESC_AMY
-                + TAG_DESC_FRIEND + LESSON_DESC_MON;
+                + TAG_DESC_FRIEND;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
                 .withTelegram(VALID_TELEGRAM_AMY)
-                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).withLessons(VALID_LESSON_DAY_AND_TME).build();
+                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -145,10 +134,10 @@ public class EditCommandParserTest {
     @Test
     public void parse_someFieldsSpecified_success() {
         Index targetIndex = INDEX_FIRST_PERSON;
-        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + EMAIL_DESC_AMY + LESSON_DESC_MON;
+        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + EMAIL_DESC_AMY;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB)
-                .withEmail(VALID_EMAIL_AMY).withLessons(VALID_LESSON_DAY_AND_TME).build();
+                .withEmail(VALID_EMAIL_AMY).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -193,11 +182,6 @@ public class EditCommandParserTest {
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
-        // lessons
-        userInput = targetIndex.getOneBased() + LESSON_DESC_MON;
-        descriptor = new EditPersonDescriptorBuilder().withLessons(VALID_LESSON_DAY_AND_TME).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
-        assertParseSuccess(parser, userInput, expectedCommand);
     }
 
     @Test
@@ -212,14 +196,14 @@ public class EditCommandParserTest {
         assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
 
         // invalid followed by valid
-        userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + INVALID_PHONE_DESC + INVALID_LESSON_DESC;
+        userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + INVALID_PHONE_DESC;
 
         assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
 
         // multiple valid fields repeated
         userInput = targetIndex.getOneBased() + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
                 + TAG_DESC_FRIEND + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
-                + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND + LESSON_DESC_MON
+                + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND
                 + TELEGRAM_DESC_AMY + TELEGRAM_DESC_AMY;
 
         assertParseFailure(parser, userInput,
@@ -228,7 +212,7 @@ public class EditCommandParserTest {
 
         // multiple invalid values
         userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + INVALID_EMAIL_DESC
-                + INVALID_PHONE_DESC + INVALID_EMAIL_DESC + INVALID_LESSON_DESC
+                + INVALID_PHONE_DESC + INVALID_EMAIL_DESC
                 + INVALID_TELEGRAM_DESC + INVALID_TELEGRAM_DESC;
 
         assertParseFailure(parser, userInput,
@@ -241,17 +225,6 @@ public class EditCommandParserTest {
         String userInput = targetIndex.getOneBased() + TAG_EMPTY;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withTags().build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
-
-        assertParseSuccess(parser, userInput, expectedCommand);
-    }
-
-    @Test
-    public void parse_resetLessons_success() {
-        Index targetIndex = INDEX_THIRD_PERSON;
-        String userInput = targetIndex.getOneBased() + LESSON_EMPTY;
-
-        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withLessons().build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);

--- a/src/test/java/tuteez/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/tuteez/testutil/EditPersonDescriptorBuilder.java
@@ -41,7 +41,6 @@ public class EditPersonDescriptorBuilder {
         descriptor.setAddress(person.getAddress());
         descriptor.setTelegramUsername(person.getTelegramUsername());
         descriptor.setTags(person.getTags());
-        descriptor.setLessons(person.getLessons());
     }
 
     /**
@@ -95,16 +94,6 @@ public class EditPersonDescriptorBuilder {
     public EditPersonDescriptorBuilder withTags(String... tags) {
         Set<Tag> tagSet = Stream.of(tags).map(Tag::new).collect(Collectors.toSet());
         descriptor.setTags(tagSet);
-        return this;
-    }
-
-    /**
-     * Parses the {@code lessons} into a {@code Set<Lesson>} and set it to the {@code EditPersonDescriptor}
-     * that we are building.
-     */
-    public EditPersonDescriptorBuilder withLessons(String... lessons) {
-        List<Lesson> lessonLst = Stream.of(lessons).map(Lesson::new).collect(Collectors.toList());
-        descriptor.setLessons(lessonLst);
         return this;
     }
 

--- a/src/test/java/tuteez/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/tuteez/testutil/EditPersonDescriptorBuilder.java
@@ -1,6 +1,5 @@
 package tuteez.testutil;
 
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -12,7 +11,6 @@ import tuteez.model.person.Name;
 import tuteez.model.person.Person;
 import tuteez.model.person.Phone;
 import tuteez.model.person.TelegramUsername;
-import tuteez.model.person.lesson.Lesson;
 import tuteez.model.tag.Tag;
 
 /**

--- a/src/test/java/tuteez/testutil/PersonBuilder.java
+++ b/src/test/java/tuteez/testutil/PersonBuilder.java
@@ -81,7 +81,7 @@ public class PersonBuilder {
     }
 
     /**
-     * Parses the {@code lessons} into a {@code Set<Lesson>} and set it to the {@code Person} that we are building.
+     * Parses the {@code lessons} into a {@code List<Lesson>} and set it to the {@code Person} that we are building.
      */
     public PersonBuilder withLessons(String ... lessons) {
         this.lessons = SampleDataUtil.getLessonLst(lessons);


### PR DESCRIPTION
Fixes #192 

## What is this PR for?
This PR is to remove the ability to add/edit/remove `Lesson`s via `EditCommand`. This is because there are now dedicated commands for adding/removing lessons, which are `addlesson` and `deletelesson` respectively. The editing of lessons via EditCommand would also introduce an unpleasant user experience as Edit would require the user to retype all of their previously entered `Lesson`s for a particular student, which may be seen as a bug/major inconvenience.

## What does this PR do?
Remove all `Lesson` related logic from EditCommand and its Parser, as well as test cases and Utility classes like `EditPersonDescriptorBuilder`. 