### PR TITLE
Left Side Panel Not Updating After Next Lesson PassesBranch next lesson

### DIFF
--- a/src/main/java/tuteez/ui/PersonCard.java
+++ b/src/main/java/tuteez/ui/PersonCard.java
@@ -1,11 +1,15 @@
 package tuteez.ui;
 
 import java.util.Comparator;
+import java.util.logging.Logger;
 
+import javafx.animation.KeyFrame;
+import javafx.animation.Timeline;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.Region;
+import javafx.util.Duration;
 import tuteez.model.person.Person;
 import tuteez.model.person.TelegramUsername;
 import tuteez.model.person.lesson.Lesson;
@@ -16,7 +20,7 @@ import tuteez.model.person.lesson.Lesson;
 public class PersonCard extends UiPart<Region> {
 
     private static final String FXML = "PersonListCard.fxml";
-
+    private static final int REFRESH_TIME = 60;
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
      * As a consequence, UI elements' variable names cannot be set to such keywords
@@ -26,6 +30,8 @@ public class PersonCard extends UiPart<Region> {
      */
 
     public final Person person;
+    private Timeline refreshTimeline;
+    private Lesson lastDisplayedLesson = null;
     @FXML
     private Label name;
     @FXML
@@ -57,6 +63,29 @@ public class PersonCard extends UiPart<Region> {
         setEmailText(person);
         setTags(person);
         setNextLesson(person);
+        startRefreshTimeline();
+    }
+
+    /**
+     * Starts the timeline that checks the lesson status every second and updates if necessary.
+     */
+    private void startRefreshTimeline() {
+        refreshTimeline = new Timeline(
+                new KeyFrame(Duration.seconds(REFRESH_TIME), event -> refreshNextLesson())
+        );
+        refreshTimeline.setCycleCount(Timeline.INDEFINITE);
+        refreshTimeline.play();
+    }
+
+    /**
+     * Refreshes the next lesson if there is a change.
+     */
+    private void refreshNextLesson() {
+        Lesson currentLesson = person.nextLessonBasedOnCurrentTime();
+        if (currentLesson != lastDisplayedLesson) {
+            setNextLesson(person);
+            lastDisplayedLesson = currentLesson; // Update to keep track of the last displayed lesson
+        }
     }
 
     /**

--- a/src/main/java/tuteez/ui/PersonCard.java
+++ b/src/main/java/tuteez/ui/PersonCard.java
@@ -10,6 +10,7 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.Region;
 import javafx.util.Duration;
+import tuteez.commons.core.LogsCenter;
 import tuteez.model.person.Person;
 import tuteez.model.person.TelegramUsername;
 import tuteez.model.person.lesson.Lesson;
@@ -21,6 +22,12 @@ public class PersonCard extends UiPart<Region> {
 
     private static final String FXML = "PersonListCard.fxml";
     private static final int REFRESH_TIME = 60;
+    private final Logger logger = LogsCenter.getLogger(getClass());
+
+    public final Person person;
+    private Timeline refreshTimeline;
+    private Lesson lastDisplayedLesson = null;
+
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
      * As a consequence, UI elements' variable names cannot be set to such keywords
@@ -28,10 +35,6 @@ public class PersonCard extends UiPart<Region> {
      *
      * @see <a href="https://github.com/se-edu/addressbook-level4/issues/336">The issue on AddressBook level 4</a>
      */
-
-    public final Person person;
-    private Timeline refreshTimeline;
-    private Lesson lastDisplayedLesson = null;
     @FXML
     private Label name;
     @FXML
@@ -70,6 +73,9 @@ public class PersonCard extends UiPart<Region> {
      * Starts the timeline that checks the lesson status every second and updates if necessary.
      */
     private void startRefreshTimeline() {
+        if (refreshTimeline != null) {
+            refreshTimeline.stop();
+        }
         refreshTimeline = new Timeline(
                 new KeyFrame(Duration.seconds(REFRESH_TIME), event -> refreshNextLesson())
         );
@@ -83,8 +89,21 @@ public class PersonCard extends UiPart<Region> {
     private void refreshNextLesson() {
         Lesson currentLesson = person.nextLessonBasedOnCurrentTime();
         if (currentLesson != lastDisplayedLesson) {
+            logger.info(String.format("Next lesson for %s updated to: %s",
+                    person.getName().fullName,
+                    currentLesson.getDayAndTime()));
             setNextLesson(person);
             lastDisplayedLesson = currentLesson; // Update to keep track of the last displayed lesson
+        }
+    }
+
+    /**
+     * Stops the refresh timeline for updating the next lesson.
+     * This method should be called when the {@code PersonCard} is no longer needed.
+     */
+    public void stopRefreshTimeline() {
+        if (refreshTimeline != null) {
+            refreshTimeline.stop();
         }
     }
 

--- a/src/main/java/tuteez/ui/PersonListPanel.java
+++ b/src/main/java/tuteez/ui/PersonListPanel.java
@@ -33,6 +33,7 @@ public class PersonListPanel extends UiPart<Region> {
      * Custom {@code ListCell} that displays the graphics of a {@code Person} using a {@code PersonCard}.
      */
     class PersonListViewCell extends ListCell<Person> {
+        private PersonCard personCard;
         @Override
         protected void updateItem(Person person, boolean empty) {
             super.updateItem(person, empty);
@@ -40,8 +41,18 @@ public class PersonListPanel extends UiPart<Region> {
             if (empty || person == null) {
                 setGraphic(null);
                 setText(null);
+                if (personCard != null) {
+                    personCard.stopRefreshTimeline();
+                }
             } else {
-                setGraphic(new PersonCard(person, getIndex() + 1).getRoot());
+                if (personCard == null || personCard.person != person) {
+                    // Create a new PersonCard only if person changes
+                    if (personCard != null) {
+                        personCard.stopRefreshTimeline();
+                    }
+                    personCard = new PersonCard(person, getIndex() + 1);
+                }
+                setGraphic(personCard.getRoot());
             }
         }
     }


### PR DESCRIPTION
Resolve #193
### What is this pull request for?
This pull request updates PersonCard to refresh the next lesson display every minute. It also modifies PersonListPanel to stop the existing timeline in a PersonCard when a Person is edited, preventing multiple overlapping timelines which could lead to redundant logging and performance issues.

### What will this pull request do?
- Added a method in PersonCard to refresh the next lesson every minute.
- Updated PersonListPanel to stop the refresh timeline in PersonCard if the Person entry is edited.