### PR TITLE
Refactor `find` command to have `l/` parameter

### DIFF
--- a/src/main/java/tuteez/logic/commands/FindCommand.java
+++ b/src/main/java/tuteez/logic/commands/FindCommand.java
@@ -2,7 +2,8 @@ package tuteez.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static tuteez.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON;
+import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON_DAY;
+import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON_TIME;
 import static tuteez.logic.parser.CliSyntax.PREFIX_NAME;
 import static tuteez.logic.parser.CliSyntax.PREFIX_TAG;
 
@@ -30,8 +31,9 @@ public class FindCommand extends Command {
             + "[" + PREFIX_NAME + "NAME_KEYWORDS...] "
             + "[" + PREFIX_ADDRESS + "ADDRESS_KEYWORDS...] "
             + "[" + PREFIX_TAG + "TAG_KEYWORDS...] "
-            + "[" + PREFIX_LESSON + "LESSON_KEYWORDS...]\n"
-            + "Example: " + COMMAND_WORD + PREFIX_NAME + " alice charlie" + PREFIX_ADDRESS + "jurong";
+            + "[" + PREFIX_LESSON_DAY + "LESSON_DAY_KEYWORDS...]"
+            + "[" + PREFIX_LESSON_TIME + "LESSON_TIME_KEYWORDS...]\n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "alice charlie " + PREFIX_ADDRESS + "jurong";
 
     private static final Logger logger = LogsCenter.getLogger(FindCommand.class);
 

--- a/src/main/java/tuteez/logic/commands/FindCommand.java
+++ b/src/main/java/tuteez/logic/commands/FindCommand.java
@@ -83,4 +83,9 @@ public class FindCommand extends Command {
                 .add("predicate", combinedPredicate)
                 .toString();
     }
+
+    @Override
+    public int hashCode() {
+        return combinedPredicate.hashCode();
+    }
 }

--- a/src/main/java/tuteez/logic/parser/CliSyntax.java
+++ b/src/main/java/tuteez/logic/parser/CliSyntax.java
@@ -13,6 +13,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_TELEGRAM = new Prefix("tg/");
     public static final Prefix PREFIX_LESSON = new Prefix("l/");
+    public static final Prefix PREFIX_LESSON_DAY = new Prefix("ld/");
+    public static final Prefix PREFIX_LESSON_TIME = new Prefix("lt/");
     public static final Prefix PREFIX_REMARK = new Prefix("r/");
     public static final Prefix PREFIX_REMARK_INDEX = new Prefix("ri/");
     public static final Prefix PREFIX_LESSON_INDEX = new Prefix("li/");

--- a/src/main/java/tuteez/logic/parser/FindCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/FindCommandParser.java
@@ -4,7 +4,6 @@ import static tuteez.logic.Messages.MESSAGE_EMPTY_KEYWORD;
 import static tuteez.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static tuteez.logic.Messages.MESSAGE_MISSING_PREFIX_FOR_FIND;
 import static tuteez.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON;
 import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON_DAY;
 import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON_TIME;
 import static tuteez.logic.parser.CliSyntax.PREFIX_NAME;
@@ -20,12 +19,10 @@ import java.util.function.Predicate;
 import tuteez.logic.commands.FindCommand;
 import tuteez.logic.parser.exceptions.ParseException;
 import tuteez.model.person.Person;
-import tuteez.model.person.lesson.Day;
-import tuteez.model.person.lesson.Lesson;
 import tuteez.model.person.predicates.AddressContainsKeywordsPredicate;
 import tuteez.model.person.predicates.CombinedPredicate;
-import tuteez.model.person.predicates.LessonTimeContainsKeywordsPredicate;
 import tuteez.model.person.predicates.LessonDayContainsKeywordsPredicate;
+import tuteez.model.person.predicates.LessonTimeContainsKeywordsPredicate;
 import tuteez.model.person.predicates.NameContainsKeywordsPredicate;
 import tuteez.model.person.predicates.TagContainsKeywordsPredicate;
 
@@ -49,7 +46,7 @@ public class FindCommandParser implements Parser<FindCommand> {
                 PREFIX_TAG, PREFIX_LESSON_DAY, PREFIX_LESSON_TIME);
 
         boolean hasAtLeastOnePrefix = ArgumentTokenizer.checkHasAtLeastOnePrefix(argMultimap, PREFIX_NAME,
-                PREFIX_ADDRESS, PREFIX_TAG, PREFIX_LESSON, PREFIX_LESSON_DAY, PREFIX_LESSON_TIME);
+                PREFIX_ADDRESS, PREFIX_TAG, PREFIX_LESSON_DAY, PREFIX_LESSON_TIME);
         if (!hasAtLeastOnePrefix) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_PREFIX_FOR_FIND));
         }

--- a/src/main/java/tuteez/logic/parser/FindCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/FindCommandParser.java
@@ -5,6 +5,7 @@ import static tuteez.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static tuteez.logic.Messages.MESSAGE_MISSING_PREFIX_FOR_FIND;
 import static tuteez.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON;
+import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON_DAY;
 import static tuteez.logic.parser.CliSyntax.PREFIX_NAME;
 import static tuteez.logic.parser.CliSyntax.PREFIX_TAG;
 
@@ -19,9 +20,11 @@ import java.util.function.Predicate;
 import tuteez.logic.commands.FindCommand;
 import tuteez.logic.parser.exceptions.ParseException;
 import tuteez.model.person.Person;
+import tuteez.model.person.lesson.Day;
 import tuteez.model.person.predicates.AddressContainsKeywordsPredicate;
 import tuteez.model.person.predicates.CombinedPredicate;
 import tuteez.model.person.predicates.LessonContainsKeywordsPredicate;
+import tuteez.model.person.predicates.LessonDayContainsKeywordsPredicate;
 import tuteez.model.person.predicates.NameContainsKeywordsPredicate;
 import tuteez.model.person.predicates.TagContainsKeywordsPredicate;
 
@@ -42,10 +45,10 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_ADDRESS,
-                PREFIX_TAG, PREFIX_LESSON);
+                PREFIX_TAG, PREFIX_LESSON, PREFIX_LESSON_DAY);
 
         boolean hasAtLeastOnePrefix = ArgumentTokenizer.checkHasAtLeastOnePrefix(argMultimap, PREFIX_NAME,
-                PREFIX_ADDRESS, PREFIX_TAG, PREFIX_LESSON);
+                PREFIX_ADDRESS, PREFIX_TAG, PREFIX_LESSON, PREFIX_LESSON_DAY);
         if (!hasAtLeastOnePrefix) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_PREFIX_FOR_FIND));
         }
@@ -62,6 +65,7 @@ public class FindCommandParser implements Parser<FindCommand> {
         addPredicateIfPresent(argMultimap, predicates, PREFIX_ADDRESS, AddressContainsKeywordsPredicate::new);
         addPredicateIfPresent(argMultimap, predicates, PREFIX_TAG, TagContainsKeywordsPredicate::new);
         addPredicateIfPresent(argMultimap, predicates, PREFIX_LESSON, LessonContainsKeywordsPredicate::new);
+        addLessonDayPredicateIfPresent(argMultimap, predicates);
 
         return predicates;
     }
@@ -74,16 +78,42 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
     }
 
-    private <T> T parseWithPredicate(ArgumentMultimap argMultimap, Prefix prefix,
-                                      Function<List<String>, T> predicateConstructor) throws ParseException {
+    private String parseValue(ArgumentMultimap argMultimap, Prefix prefix) throws ParseException {
         Optional<String> value = argMultimap.getValue(prefix);
         String keywords = value.get();
         if (keywords.trim().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_EMPTY_KEYWORD, prefix));
         }
+        return keywords;
+    }
 
-        return value
-                .map(v -> predicateConstructor.apply(Arrays.asList(v.split("\\s+"))))
-                .orElseGet(() -> predicateConstructor.apply(Collections.emptyList()));
+    private <T> T parseWithPredicate(ArgumentMultimap argMultimap, Prefix prefix,
+                                      Function<List<String>, T> predicateConstructor) throws ParseException {
+        String keywords = parseValue(argMultimap, prefix);
+        return predicateConstructor.apply(Arrays.asList(keywords.split("\\s+")));
+    }
+
+    private void addLessonDayPredicateIfPresent(ArgumentMultimap argMultimap,
+                                                List<Predicate<Person>> predicates) throws ParseException {
+        if (argMultimap.getValue(PREFIX_LESSON_DAY).isPresent()) {
+            predicates.add(parseWithLessonDayPredicate(argMultimap));
+        }
+    }
+
+    private Predicate<Person> parseWithLessonDayPredicate(ArgumentMultimap argMultimap) throws ParseException {
+        String keywords = parseValue(argMultimap, PREFIX_LESSON_DAY);
+
+        List<String> dayKeywords = Arrays.asList(keywords.split("\\s+"));
+        validateDayKeywords(dayKeywords);
+
+        return new LessonDayContainsKeywordsPredicate(dayKeywords);
+    }
+
+    private void validateDayKeywords(List<String> keywords) throws ParseException {
+        for (String keyword : keywords) {
+            if (!Day.isValidDay(keyword)) {
+                throw new ParseException("Invalid day keyword inputted after " + PREFIX_LESSON_DAY + ": " + keyword);
+            }
+        }
     }
 }

--- a/src/main/java/tuteez/logic/parser/FindCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/FindCommandParser.java
@@ -6,12 +6,12 @@ import static tuteez.logic.Messages.MESSAGE_MISSING_PREFIX_FOR_FIND;
 import static tuteez.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON;
 import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON_DAY;
+import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON_TIME;
 import static tuteez.logic.parser.CliSyntax.PREFIX_NAME;
 import static tuteez.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -21,9 +21,10 @@ import tuteez.logic.commands.FindCommand;
 import tuteez.logic.parser.exceptions.ParseException;
 import tuteez.model.person.Person;
 import tuteez.model.person.lesson.Day;
+import tuteez.model.person.lesson.Lesson;
 import tuteez.model.person.predicates.AddressContainsKeywordsPredicate;
 import tuteez.model.person.predicates.CombinedPredicate;
-import tuteez.model.person.predicates.LessonContainsKeywordsPredicate;
+import tuteez.model.person.predicates.LessonTimeContainsKeywordsPredicate;
 import tuteez.model.person.predicates.LessonDayContainsKeywordsPredicate;
 import tuteez.model.person.predicates.NameContainsKeywordsPredicate;
 import tuteez.model.person.predicates.TagContainsKeywordsPredicate;
@@ -45,10 +46,10 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_ADDRESS,
-                PREFIX_TAG, PREFIX_LESSON, PREFIX_LESSON_DAY);
+                PREFIX_TAG, PREFIX_LESSON_DAY, PREFIX_LESSON_TIME);
 
         boolean hasAtLeastOnePrefix = ArgumentTokenizer.checkHasAtLeastOnePrefix(argMultimap, PREFIX_NAME,
-                PREFIX_ADDRESS, PREFIX_TAG, PREFIX_LESSON, PREFIX_LESSON_DAY);
+                PREFIX_ADDRESS, PREFIX_TAG, PREFIX_LESSON, PREFIX_LESSON_DAY, PREFIX_LESSON_TIME);
         if (!hasAtLeastOnePrefix) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_PREFIX_FOR_FIND));
         }
@@ -64,8 +65,8 @@ public class FindCommandParser implements Parser<FindCommand> {
         addPredicateIfPresent(argMultimap, predicates, PREFIX_NAME, NameContainsKeywordsPredicate::new);
         addPredicateIfPresent(argMultimap, predicates, PREFIX_ADDRESS, AddressContainsKeywordsPredicate::new);
         addPredicateIfPresent(argMultimap, predicates, PREFIX_TAG, TagContainsKeywordsPredicate::new);
-        addPredicateIfPresent(argMultimap, predicates, PREFIX_LESSON, LessonContainsKeywordsPredicate::new);
         addLessonDayPredicateIfPresent(argMultimap, predicates);
+        addLessonTimePredicateIfPresent(argMultimap, predicates);
 
         return predicates;
     }
@@ -75,6 +76,20 @@ public class FindCommandParser implements Parser<FindCommand> {
             throws ParseException {
         if (argMultimap.getValue(prefix).isPresent()) {
             predicates.add(parseWithPredicate(argMultimap, prefix, predicateConstructor));
+        }
+    }
+
+    private void addLessonDayPredicateIfPresent(ArgumentMultimap argMultimap,
+                                                List<Predicate<Person>> predicates) throws ParseException {
+        if (argMultimap.getValue(PREFIX_LESSON_DAY).isPresent()) {
+            predicates.add(parseWithLessonDayPredicate(argMultimap));
+        }
+    }
+
+    private void addLessonTimePredicateIfPresent(ArgumentMultimap argMultimap,
+                                                List<Predicate<Person>> predicates) throws ParseException {
+        if (argMultimap.getValue(PREFIX_LESSON_TIME).isPresent()) {
+            predicates.add(parseWithLessonTimePredicate(argMultimap));
         }
     }
 
@@ -93,27 +108,31 @@ public class FindCommandParser implements Parser<FindCommand> {
         return predicateConstructor.apply(Arrays.asList(keywords.split("\\s+")));
     }
 
-    private void addLessonDayPredicateIfPresent(ArgumentMultimap argMultimap,
-                                                List<Predicate<Person>> predicates) throws ParseException {
-        if (argMultimap.getValue(PREFIX_LESSON_DAY).isPresent()) {
-            predicates.add(parseWithLessonDayPredicate(argMultimap));
-        }
-    }
-
     private Predicate<Person> parseWithLessonDayPredicate(ArgumentMultimap argMultimap) throws ParseException {
         String keywords = parseValue(argMultimap, PREFIX_LESSON_DAY);
-
         List<String> dayKeywords = Arrays.asList(keywords.split("\\s+"));
-        validateDayKeywords(dayKeywords);
-
+        for (String dayKeyword : dayKeywords) {
+            try {
+                ParserUtil.checkValidLessonDayInfo(dayKeyword);
+            } catch (ParseException e) {
+                throw new ParseException("Invalid day keyword inputted after " + PREFIX_LESSON_DAY + ": "
+                        + dayKeyword + "\n" + e.getMessage());
+            }
+        }
         return new LessonDayContainsKeywordsPredicate(dayKeywords);
     }
 
-    private void validateDayKeywords(List<String> keywords) throws ParseException {
-        for (String keyword : keywords) {
-            if (!Day.isValidDay(keyword)) {
-                throw new ParseException("Invalid day keyword inputted after " + PREFIX_LESSON_DAY + ": " + keyword);
+    private Predicate<Person> parseWithLessonTimePredicate(ArgumentMultimap argMultimap) throws ParseException {
+        String keywords = parseValue(argMultimap, PREFIX_LESSON_TIME);
+        List<String> timeKeywords = Arrays.asList(keywords.split("\\s+"));
+        for (String timeKeyword : timeKeywords) {
+            try {
+                ParserUtil.checkValidLessonTimeInfo(timeKeyword);
+            } catch (ParseException e) {
+                throw new ParseException("Invalid time keyword inputted after " + PREFIX_LESSON_TIME + ": "
+                        + timeKeyword + "\n" + e.getMessage());
             }
         }
+        return new LessonTimeContainsKeywordsPredicate(timeKeywords);
     }
 }

--- a/src/main/java/tuteez/model/person/predicates/CombinedPredicate.java
+++ b/src/main/java/tuteez/model/person/predicates/CombinedPredicate.java
@@ -42,6 +42,7 @@ public class CombinedPredicate implements Predicate<Person> {
         CombinedPredicate otherCombinedPredicate = (CombinedPredicate) other;
         return predicates.equals(otherCombinedPredicate.predicates);
     }
+
     @Override
     public int hashCode() {
         return Objects.hash(predicates);

--- a/src/main/java/tuteez/model/person/predicates/LessonDayContainsKeywordsPredicate.java
+++ b/src/main/java/tuteez/model/person/predicates/LessonDayContainsKeywordsPredicate.java
@@ -13,7 +13,7 @@ import tuteez.model.person.lesson.Lesson;
  * Tests that a {@code Person}'s {@code Lesson} day matches any of the keywords given.
  */
 public class LessonDayContainsKeywordsPredicate implements Predicate<Person> {
-    private static Logger logger = LogsCenter.getLogger(LessonContainsKeywordsPredicate.class);
+    private static Logger logger = LogsCenter.getLogger(LessonDayContainsKeywordsPredicate.class);
     private final List<String> keywords;
 
     public LessonDayContainsKeywordsPredicate(List<String> keywords) {
@@ -27,7 +27,7 @@ public class LessonDayContainsKeywordsPredicate implements Predicate<Person> {
                 .anyMatch(lesson -> matchesAnyKeyword(lesson));
 
         if (!hasMatch) {
-            logger.info("No matches found for person: " + person.getName());
+            logger.info("No matches for lesson day found for person: " + person.getName());
         }
 
         return hasMatch;

--- a/src/main/java/tuteez/model/person/predicates/LessonDayContainsKeywordsPredicate.java
+++ b/src/main/java/tuteez/model/person/predicates/LessonDayContainsKeywordsPredicate.java
@@ -1,0 +1,58 @@
+package tuteez.model.person.predicates;
+
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.logging.Logger;
+
+import tuteez.commons.core.LogsCenter;
+import tuteez.model.person.Person;
+import tuteez.model.person.lesson.Day;
+import tuteez.model.person.lesson.Lesson;
+
+/**
+ * Tests that a {@code Person}'s {@code Lesson} day matches any of the keywords given.
+ */
+public class LessonDayContainsKeywordsPredicate implements Predicate<Person> {
+    private static Logger logger = LogsCenter.getLogger(LessonContainsKeywordsPredicate.class);
+    private final List<String> keywords;
+
+    public LessonDayContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+
+        boolean hasMatch = person.getLessons().stream()
+                .anyMatch(lesson -> matchesAnyKeyword(lesson));
+
+        if (!hasMatch) {
+            logger.info("No matches found for person: " + person.getName());
+        }
+
+        return hasMatch;
+    }
+
+    private boolean matchesAnyKeyword(Lesson lesson) {
+        return keywords.stream().anyMatch(keyword -> {
+            Day day = Day.convertDayToEnum(keyword);
+            return lesson.getLessonDay() == day;
+        });
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof LessonDayContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        LessonDayContainsKeywordsPredicate otherLessonDayContainsKeywordsPredicate =
+                (LessonDayContainsKeywordsPredicate) other;
+        return keywords.equals(otherLessonDayContainsKeywordsPredicate.keywords);
+    }
+}

--- a/src/main/java/tuteez/model/person/predicates/LessonTimeContainsKeywordsPredicate.java
+++ b/src/main/java/tuteez/model/person/predicates/LessonTimeContainsKeywordsPredicate.java
@@ -12,11 +12,11 @@ import tuteez.model.person.lesson.Lesson;
 /**
  * Tests that a {@code Person}'s {@code Lesson} matches any of the keywords given.
  */
-public class LessonContainsKeywordsPredicate implements Predicate<Person> {
-    private static Logger logger = LogsCenter.getLogger(LessonContainsKeywordsPredicate.class);
+public class LessonTimeContainsKeywordsPredicate implements Predicate<Person> {
+    private static Logger logger = LogsCenter.getLogger(LessonTimeContainsKeywordsPredicate.class);
     private final List<String> keywords;
 
-    public LessonContainsKeywordsPredicate(List<String> keywords) {
+    public LessonTimeContainsKeywordsPredicate(List<String> keywords) {
         this.keywords = keywords;
     }
 
@@ -27,7 +27,7 @@ public class LessonContainsKeywordsPredicate implements Predicate<Person> {
                 .anyMatch(lesson -> matchesAnyKeyword(lesson));
 
         if (!hasMatch) {
-            logger.info("No matches found for person: " + person.getName());
+            logger.info("No matches for lesson time found for person: " + person.getName());
         }
 
         return hasMatch;
@@ -35,8 +35,7 @@ public class LessonContainsKeywordsPredicate implements Predicate<Person> {
 
     private boolean matchesAnyKeyword(Lesson lesson) {
         return keywords.stream().anyMatch(keyword -> (
-                Day.isValidDay(keyword) && lesson.getLessonDay().toString().equalsIgnoreCase(keyword))
-                || (Lesson.isValidTimeRange(keyword) && checkOverlappingTimeRange(lesson, keyword)));
+                checkOverlappingTimeRange(lesson, keyword)));
     }
 
     private boolean checkOverlappingTimeRange(Lesson lesson, String keyword) {
@@ -50,11 +49,11 @@ public class LessonContainsKeywordsPredicate implements Predicate<Person> {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof LessonContainsKeywordsPredicate)) {
+        if (!(other instanceof LessonTimeContainsKeywordsPredicate)) {
             return false;
         }
 
-        LessonContainsKeywordsPredicate otherLessonContainsKeywordsPredicate = (LessonContainsKeywordsPredicate) other;
-        return keywords.equals(otherLessonContainsKeywordsPredicate.keywords);
+        LessonTimeContainsKeywordsPredicate otherLessonTimeContainsKeywordsPredicate = (LessonTimeContainsKeywordsPredicate) other;
+        return keywords.equals(otherLessonTimeContainsKeywordsPredicate.keywords);
     }
 }

--- a/src/main/java/tuteez/model/person/predicates/LessonTimeContainsKeywordsPredicate.java
+++ b/src/main/java/tuteez/model/person/predicates/LessonTimeContainsKeywordsPredicate.java
@@ -6,7 +6,6 @@ import java.util.logging.Logger;
 
 import tuteez.commons.core.LogsCenter;
 import tuteez.model.person.Person;
-import tuteez.model.person.lesson.Day;
 import tuteez.model.person.lesson.Lesson;
 
 /**
@@ -53,7 +52,8 @@ public class LessonTimeContainsKeywordsPredicate implements Predicate<Person> {
             return false;
         }
 
-        LessonTimeContainsKeywordsPredicate otherLessonTimeContainsKeywordsPredicate = (LessonTimeContainsKeywordsPredicate) other;
+        LessonTimeContainsKeywordsPredicate otherLessonTimeContainsKeywordsPredicate =
+                (LessonTimeContainsKeywordsPredicate) other;
         return keywords.equals(otherLessonTimeContainsKeywordsPredicate.keywords);
     }
 }

--- a/src/test/java/tuteez/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/tuteez/logic/parser/FindCommandParserTest.java
@@ -5,7 +5,8 @@ import static tuteez.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static tuteez.logic.Messages.MESSAGE_MISSING_PREFIX_FOR_FIND;
 import static tuteez.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static tuteez.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON;
+import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON_DAY;
+import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON_TIME;
 import static tuteez.logic.parser.CliSyntax.PREFIX_NAME;
 import static tuteez.logic.parser.CliSyntax.PREFIX_TAG;
 import static tuteez.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -17,8 +18,10 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import tuteez.logic.commands.FindCommand;
+import tuteez.model.person.lesson.Lesson;
 import tuteez.model.person.predicates.AddressContainsKeywordsPredicate;
 import tuteez.model.person.predicates.CombinedPredicate;
+import tuteez.model.person.predicates.LessonDayContainsKeywordsPredicate;
 import tuteez.model.person.predicates.LessonTimeContainsKeywordsPredicate;
 import tuteez.model.person.predicates.NameContainsKeywordsPredicate;
 import tuteez.model.person.predicates.TagContainsKeywordsPredicate;
@@ -31,18 +34,24 @@ public class FindCommandParserTest {
             new AddressContainsKeywordsPredicate(Arrays.asList("choa", "jurong"));
     private static final TagContainsKeywordsPredicate TAG_PREDICATE =
             new TagContainsKeywordsPredicate(Arrays.asList("math", "secondary4"));
-    private static final LessonTimeContainsKeywordsPredicate LESSON_PREDICATE =
-            new LessonTimeContainsKeywordsPredicate(Arrays.asList("monday", "1900-2200"));
+    private static final LessonDayContainsKeywordsPredicate LESSON_DAY_PREDICATE =
+            new LessonDayContainsKeywordsPredicate(Arrays.asList("monday", "wed"));
+    private static final LessonTimeContainsKeywordsPredicate LESSON_TIME_PREDICATE =
+            new LessonTimeContainsKeywordsPredicate(Arrays.asList("1200-1330", "1900-2200"));
 
     private static final String VALID_NAME_DESC = " " + PREFIX_NAME + "alice bob";
     private static final String VALID_ADDRESS_DESC = " " + PREFIX_ADDRESS + "choa jurong";
     private static final String VALID_TAG_DESC = " " + PREFIX_TAG + "math secondary4";
-    private static final String VALID_LESSON_DESC = " " + PREFIX_LESSON + "monday 1900-2200";
+    private static final String VALID_LESSON_DAY_DESC = " " + PREFIX_LESSON_DAY + "monday wed";
+    private static final String VALID_LESSON_TIME_DESC = " " + PREFIX_LESSON_TIME + "1200-1330 1900-2200";
 
     private static final String VALID_NAME_DESC_WITH_SPACE = " " + PREFIX_NAME + "\n alice \n \t bob  \t";
     private static final String VALID_ADDRESS_DESC_WITH_SPACE = " " + PREFIX_ADDRESS + "\n choa \n \t jurong  \t";
     private static final String VALID_TAG_DESC_WITH_SPACE = " " + PREFIX_TAG + "\n math \n \t secondary4  \t";
-    private static final String VALID_LESSON_DESC_WITH_SPACE = " " + PREFIX_LESSON + "\n monday \n \t 1900-2200  \t";
+    private static final String VALID_LESSON_DAY_DESC_WITH_SPACE = " " + PREFIX_LESSON_DAY
+            + "\n monday \n \t wed  \t";
+    private static final String VALID_LESSON_TIME_DESC_WITH_SPACE = " " + PREFIX_LESSON_TIME
+            + "\n 1200-1330 \n \t 1900-2200  \t";
 
     private FindCommandParser parser = new FindCommandParser();
 
@@ -83,26 +92,37 @@ public class FindCommandParserTest {
     }
 
     @Test
-    public void parse_validLessonPrefixArg_returnsFindCommand() {
+    public void parse_validLessonDayPrefixArg_returnsFindCommand() {
         // no leading and trailing whitespaces
-        FindCommand expectedFindCommand = new FindCommand(new CombinedPredicate(List.of(LESSON_PREDICATE)));
-        assertParseSuccess(parser, VALID_LESSON_DESC, expectedFindCommand);
+        FindCommand expectedFindCommand = new FindCommand(new CombinedPredicate(List.of(LESSON_DAY_PREDICATE)));
+        assertParseSuccess(parser, VALID_LESSON_DAY_DESC, expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, VALID_LESSON_DESC_WITH_SPACE, expectedFindCommand);
+        assertParseSuccess(parser, VALID_LESSON_DAY_DESC_WITH_SPACE, expectedFindCommand);
+    }
+
+    @Test
+    public void parse_validLessonTimePrefixArg_returnsFindCommand() {
+        // no leading and trailing whitespaces
+        FindCommand expectedFindCommand = new FindCommand(new CombinedPredicate(List.of(LESSON_TIME_PREDICATE)));
+        assertParseSuccess(parser, VALID_LESSON_TIME_DESC, expectedFindCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, VALID_LESSON_TIME_DESC_WITH_SPACE, expectedFindCommand);
     }
 
     @Test
     public void parse_validAllPrefixArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand = new FindCommand(new CombinedPredicate(List.of(NAME_PREDICATE,
-                ADDRESS_PREDICATE, TAG_PREDICATE, LESSON_PREDICATE)));
+                ADDRESS_PREDICATE, TAG_PREDICATE, LESSON_DAY_PREDICATE, LESSON_TIME_PREDICATE)));
         assertParseSuccess(parser, VALID_NAME_DESC + VALID_ADDRESS_DESC + VALID_TAG_DESC
-                + VALID_LESSON_DESC, expectedFindCommand);
+                + VALID_LESSON_DAY_DESC + VALID_LESSON_TIME_DESC, expectedFindCommand);
 
         // multiple whitespaces between keywords
         assertParseSuccess(parser, VALID_NAME_DESC_WITH_SPACE + VALID_ADDRESS_DESC_WITH_SPACE
-                + VALID_TAG_DESC_WITH_SPACE + VALID_LESSON_DESC_WITH_SPACE, expectedFindCommand);
+                + VALID_TAG_DESC_WITH_SPACE + VALID_LESSON_DAY_DESC_WITH_SPACE + VALID_LESSON_TIME_DESC_WITH_SPACE,
+                expectedFindCommand);
     }
 
     @Test
@@ -114,11 +134,41 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_emptyKeywordAfterPrefix_throwsParseException() {
-        assertParseFailure(parser, " n/ ", String.format(MESSAGE_EMPTY_KEYWORD, PREFIX_NAME));
-        assertParseFailure(parser, " a/ ", String.format(MESSAGE_EMPTY_KEYWORD, PREFIX_ADDRESS));
-        assertParseFailure(parser, " t/ ", String.format(MESSAGE_EMPTY_KEYWORD, PREFIX_TAG));
-        assertParseFailure(parser, " l/ ", String.format(MESSAGE_EMPTY_KEYWORD, PREFIX_LESSON));
+        assertParseFailure(parser, " " + PREFIX_NAME, String.format(MESSAGE_EMPTY_KEYWORD, PREFIX_NAME));
+        assertParseFailure(parser, " " + PREFIX_ADDRESS, String.format(MESSAGE_EMPTY_KEYWORD, PREFIX_ADDRESS));
+        assertParseFailure(parser, " " + PREFIX_TAG, String.format(MESSAGE_EMPTY_KEYWORD, PREFIX_TAG));
+        assertParseFailure(parser, " " + PREFIX_LESSON_DAY, String.format(MESSAGE_EMPTY_KEYWORD,
+                PREFIX_LESSON_DAY));
+        assertParseFailure(parser, " " + PREFIX_LESSON_TIME, String.format(MESSAGE_EMPTY_KEYWORD,
+                PREFIX_LESSON_TIME));
 
-        assertParseFailure(parser, " n/ a/ t/ l/ ", String.format(MESSAGE_EMPTY_KEYWORD, PREFIX_NAME));
+        assertParseFailure(parser, " " + PREFIX_NAME + " " + PREFIX_ADDRESS,
+                String.format(MESSAGE_EMPTY_KEYWORD, PREFIX_NAME));
+    }
+
+    @Test
+    public void parse_invalidLessonDay_throwsParseException() {
+        // One invalid keyword
+        assertParseFailure(parser, " " + PREFIX_LESSON_DAY + "INVALID",
+                "Invalid day keyword inputted after ld/: INVALID\n"
+                        + Lesson.MESSAGE_INVALID_LESSON_DAY);
+
+        // One valid keyword and one invalid keyword
+        assertParseFailure(parser, " " + PREFIX_LESSON_DAY + "MON INVALID TUE",
+                "Invalid day keyword inputted after ld/: INVALID\n"
+                        + Lesson.MESSAGE_INVALID_LESSON_DAY);
+    }
+
+    @Test
+    public void parse_invalidLessonTimeRange_throwsParseException() {
+        // One invalid keyword
+        assertParseFailure(parser, " lt/2500-2600",
+                "Invalid time keyword inputted after lt/: 2500-2600\n"
+                        + Lesson.MESSAGE_INVALID_LESSON_TIME);
+
+        // One valid keyword and one invalid keyword
+        assertParseFailure(parser, " lt/1000-1100 2500-2600",
+                "Invalid time keyword inputted after lt/: 2500-2600\n"
+                        + Lesson.MESSAGE_INVALID_LESSON_TIME);
     }
 }

--- a/src/test/java/tuteez/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/tuteez/logic/parser/FindCommandParserTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 import tuteez.logic.commands.FindCommand;
 import tuteez.model.person.predicates.AddressContainsKeywordsPredicate;
 import tuteez.model.person.predicates.CombinedPredicate;
-import tuteez.model.person.predicates.LessonContainsKeywordsPredicate;
+import tuteez.model.person.predicates.LessonTimeContainsKeywordsPredicate;
 import tuteez.model.person.predicates.NameContainsKeywordsPredicate;
 import tuteez.model.person.predicates.TagContainsKeywordsPredicate;
 
@@ -31,8 +31,8 @@ public class FindCommandParserTest {
             new AddressContainsKeywordsPredicate(Arrays.asList("choa", "jurong"));
     private static final TagContainsKeywordsPredicate TAG_PREDICATE =
             new TagContainsKeywordsPredicate(Arrays.asList("math", "secondary4"));
-    private static final LessonContainsKeywordsPredicate LESSON_PREDICATE =
-            new LessonContainsKeywordsPredicate(Arrays.asList("monday", "1900-2200"));
+    private static final LessonTimeContainsKeywordsPredicate LESSON_PREDICATE =
+            new LessonTimeContainsKeywordsPredicate(Arrays.asList("monday", "1900-2200"));
 
     private static final String VALID_NAME_DESC = " " + PREFIX_NAME + "alice bob";
     private static final String VALID_ADDRESS_DESC = " " + PREFIX_ADDRESS + "choa jurong";

--- a/src/test/java/tuteez/model/person/predicates/LessonDayContainsKeywordsPredicateTest.java
+++ b/src/test/java/tuteez/model/person/predicates/LessonDayContainsKeywordsPredicateTest.java
@@ -1,0 +1,58 @@
+package tuteez.model.person.predicates;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import tuteez.model.person.Person;
+import tuteez.testutil.PersonBuilder;
+
+public class LessonDayContainsKeywordsPredicateTest {
+    private static final Person personWithLesson =
+            new PersonBuilder().withName("bob").withLessons("monday 1730-1830").build();
+    @Test
+    public void test_lessonMatchesDayKeyword_returnsTrue() {
+        List<String> keywords = List.of("monday");
+        LessonDayContainsKeywordsPredicate predicate = new LessonDayContainsKeywordsPredicate(keywords);
+        assertTrue(predicate.test(personWithLesson));
+    }
+
+    @Test
+    public void test_lessonMatchesDayKeywordAbbreviation_returnsTrue() {
+        List<String> keywords = List.of("mon");
+        LessonDayContainsKeywordsPredicate predicate = new LessonDayContainsKeywordsPredicate(keywords);
+        assertTrue(predicate.test(personWithLesson));
+    }
+
+    @Test
+    public void test_lessonDoesNotMatchAnyKeyword_returnsFalse() {
+        List<String> keywords = List.of("tuesday", "wed", "wednesday");
+        LessonDayContainsKeywordsPredicate predicate = new LessonDayContainsKeywordsPredicate(keywords);
+        assertFalse(predicate.test(personWithLesson));
+    }
+
+    @Test
+    public void equals_sameKeywords_returnsTrue() {
+        List<String> keywords1 = List.of("friday");
+        List<String> keywords2 = List.of("friday");
+
+        LessonDayContainsKeywordsPredicate predicate1 = new LessonDayContainsKeywordsPredicate(keywords1);
+        LessonDayContainsKeywordsPredicate predicate2 = new LessonDayContainsKeywordsPredicate(keywords2);
+
+        assertTrue(predicate1.equals(predicate2));
+    }
+
+    @Test
+    public void equals_differentKeywords_returnsFalse() {
+        List<String> keywords1 = List.of("tuesday");
+        List<String> keywords2 = List.of("thursday");
+
+        LessonDayContainsKeywordsPredicate predicate1 = new LessonDayContainsKeywordsPredicate(keywords1);
+        LessonDayContainsKeywordsPredicate predicate2 = new LessonDayContainsKeywordsPredicate(keywords2);
+
+        assertFalse(predicate1.equals(predicate2));
+    }
+}

--- a/src/test/java/tuteez/model/person/predicates/LessonTimeContainsKeywordsPredicateTest.java
+++ b/src/test/java/tuteez/model/person/predicates/LessonTimeContainsKeywordsPredicateTest.java
@@ -10,41 +10,41 @@ import org.junit.jupiter.api.Test;
 import tuteez.model.person.Person;
 import tuteez.testutil.PersonBuilder;
 
-public class LessonContainsKeywordsPredicateTest {
+public class LessonTimeContainsKeywordsPredicateTest {
 
     private static final Person personWithLesson =
             new PersonBuilder().withName("bob").withLessons("monday 1730-1830").build();
     @Test
     public void test_lessonMatchesDayKeyword_returnsTrue() {
         List<String> keywords = List.of("monday");
-        LessonContainsKeywordsPredicate predicate = new LessonContainsKeywordsPredicate(keywords);
+        LessonTimeContainsKeywordsPredicate predicate = new LessonTimeContainsKeywordsPredicate(keywords);
         assertTrue(predicate.test(personWithLesson));
     }
 
     @Test
     public void test_lessonMatchesTimeRangeKeyword_returnsTrue() {
         List<String> keywordsStartBefore = List.of("1700-1800");
-        LessonContainsKeywordsPredicate predicateStartBefore = new LessonContainsKeywordsPredicate(keywordsStartBefore);
+        LessonTimeContainsKeywordsPredicate predicateStartBefore = new LessonTimeContainsKeywordsPredicate(keywordsStartBefore);
         assertTrue(predicateStartBefore.test(personWithLesson));
 
         List<String> keywordsSame = List.of("1730-1830");
-        LessonContainsKeywordsPredicate predicateSame = new LessonContainsKeywordsPredicate(keywordsSame);
+        LessonTimeContainsKeywordsPredicate predicateSame = new LessonTimeContainsKeywordsPredicate(keywordsSame);
         assertTrue(predicateSame.test(personWithLesson));
 
         List<String> keywordsEndAfter = List.of("1730-1900");
-        LessonContainsKeywordsPredicate predicateEndAfter = new LessonContainsKeywordsPredicate(keywordsEndAfter);
+        LessonTimeContainsKeywordsPredicate predicateEndAfter = new LessonTimeContainsKeywordsPredicate(keywordsEndAfter);
         assertTrue(predicateEndAfter.test(personWithLesson));
 
         List<String> keywordsStartBeforeAndEndAfter = List.of("1700-1900");
-        LessonContainsKeywordsPredicate predicateStartBeforeAndEndAfter =
-                new LessonContainsKeywordsPredicate(keywordsStartBeforeAndEndAfter);
+        LessonTimeContainsKeywordsPredicate predicateStartBeforeAndEndAfter =
+                new LessonTimeContainsKeywordsPredicate(keywordsStartBeforeAndEndAfter);
         assertTrue(predicateStartBeforeAndEndAfter.test(personWithLesson));
     }
 
     @Test
     public void test_lessonDoesNotMatchAnyKeyword_returnsFalse() {
         List<String> keywords = List.of("tuesday", "0800-1000");
-        LessonContainsKeywordsPredicate predicate = new LessonContainsKeywordsPredicate(keywords);
+        LessonTimeContainsKeywordsPredicate predicate = new LessonTimeContainsKeywordsPredicate(keywords);
         assertFalse(predicate.test(personWithLesson));
     }
 
@@ -53,8 +53,8 @@ public class LessonContainsKeywordsPredicateTest {
         List<String> keywords1 = List.of("MONDAY", "0900-1000");
         List<String> keywords2 = List.of("MONDAY", "0900-1000");
 
-        LessonContainsKeywordsPredicate predicate1 = new LessonContainsKeywordsPredicate(keywords1);
-        LessonContainsKeywordsPredicate predicate2 = new LessonContainsKeywordsPredicate(keywords2);
+        LessonTimeContainsKeywordsPredicate predicate1 = new LessonTimeContainsKeywordsPredicate(keywords1);
+        LessonTimeContainsKeywordsPredicate predicate2 = new LessonTimeContainsKeywordsPredicate(keywords2);
 
         assertTrue(predicate1.equals(predicate2));
     }
@@ -64,8 +64,8 @@ public class LessonContainsKeywordsPredicateTest {
         List<String> keywords1 = List.of("MONDAY", "0900-1000");
         List<String> keywords2 = List.of("TUESDAY", "1100-1200");
 
-        LessonContainsKeywordsPredicate predicate1 = new LessonContainsKeywordsPredicate(keywords1);
-        LessonContainsKeywordsPredicate predicate2 = new LessonContainsKeywordsPredicate(keywords2);
+        LessonTimeContainsKeywordsPredicate predicate1 = new LessonTimeContainsKeywordsPredicate(keywords1);
+        LessonTimeContainsKeywordsPredicate predicate2 = new LessonTimeContainsKeywordsPredicate(keywords2);
 
         assertFalse(predicate1.equals(predicate2));
     }

--- a/src/test/java/tuteez/model/person/predicates/LessonTimeContainsKeywordsPredicateTest.java
+++ b/src/test/java/tuteez/model/person/predicates/LessonTimeContainsKeywordsPredicateTest.java
@@ -14,12 +14,6 @@ public class LessonTimeContainsKeywordsPredicateTest {
 
     private static final Person personWithLesson =
             new PersonBuilder().withName("bob").withLessons("monday 1730-1830").build();
-    @Test
-    public void test_lessonMatchesDayKeyword_returnsTrue() {
-        List<String> keywords = List.of("monday");
-        LessonTimeContainsKeywordsPredicate predicate = new LessonTimeContainsKeywordsPredicate(keywords);
-        assertTrue(predicate.test(personWithLesson));
-    }
 
     @Test
     public void test_lessonMatchesTimeRangeKeyword_returnsTrue() {
@@ -43,15 +37,15 @@ public class LessonTimeContainsKeywordsPredicateTest {
 
     @Test
     public void test_lessonDoesNotMatchAnyKeyword_returnsFalse() {
-        List<String> keywords = List.of("tuesday", "0800-1000");
+        List<String> keywords = List.of("0800-1000");
         LessonTimeContainsKeywordsPredicate predicate = new LessonTimeContainsKeywordsPredicate(keywords);
         assertFalse(predicate.test(personWithLesson));
     }
 
     @Test
     public void equals_sameKeywords_returnsTrue() {
-        List<String> keywords1 = List.of("MONDAY", "0900-1000");
-        List<String> keywords2 = List.of("MONDAY", "0900-1000");
+        List<String> keywords1 = List.of("0900-1000");
+        List<String> keywords2 = List.of("0900-1000");
 
         LessonTimeContainsKeywordsPredicate predicate1 = new LessonTimeContainsKeywordsPredicate(keywords1);
         LessonTimeContainsKeywordsPredicate predicate2 = new LessonTimeContainsKeywordsPredicate(keywords2);
@@ -61,8 +55,8 @@ public class LessonTimeContainsKeywordsPredicateTest {
 
     @Test
     public void equals_differentKeywords_returnsFalse() {
-        List<String> keywords1 = List.of("MONDAY", "0900-1000");
-        List<String> keywords2 = List.of("TUESDAY", "1100-1200");
+        List<String> keywords1 = List.of("0900-1000");
+        List<String> keywords2 = List.of("1100-1200");
 
         LessonTimeContainsKeywordsPredicate predicate1 = new LessonTimeContainsKeywordsPredicate(keywords1);
         LessonTimeContainsKeywordsPredicate predicate2 = new LessonTimeContainsKeywordsPredicate(keywords2);


### PR DESCRIPTION
Fixes #207

## What is this PR for?
Currently, find takes in l/ as a parameter, which accepts both lesson day (eg monday) and lesson time range (eg 1000-12000).
This makes checking for valid values difficult (eg 1800-1600 is an invalid time range, but the find command does not currently detect this)

## What does this PR do?
Splits the `l/` parameter in find into `ld/` and `lt`. For these parameters, it checks that day and time range are valid.

## Note
Name, address and tag keywords do not have such extensive checks because they simply require the input not to be blank