### PR TITLE
Remove autocaps for names

### DIFF
--- a/src/main/java/tuteez/model/person/Name.java
+++ b/src/main/java/tuteez/model/person/Name.java
@@ -3,10 +3,6 @@ package tuteez.model.person;
 import static java.util.Objects.requireNonNull;
 import static tuteez.commons.util.AppUtil.checkArgument;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
 /**
  * Represents a Person's name in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
@@ -17,10 +13,6 @@ public class Name {
             "Names should only contain alphanumeric characters and spaces, and the following special characters: "
                     + "/, -, ', ., ,, (, ), &. It should not be blank.";
 
-    /*
-     * The first character of the address must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
-     */
     public static final String VALIDATION_REGEX = "\\s*[\\p{Alnum}][\\p{Alnum} /'.,()&-]*";
 
     public final String fullName;
@@ -48,39 +40,7 @@ public class Name {
     }
 
     private String processName(String name) {
-        String trimmedName = name.trim();
-        return toTitleCase(trimmedName);
-    }
-
-    private String toTitleCase(String name) {
-
-        String[] words = splitIntoWords(name);
-        return joinWordsWithTitleCase(words);
-    }
-
-    private String[] splitIntoWords(String name) {
-        return name.split("\\s+");
-    }
-
-    private String joinWordsWithTitleCase(String[] words) {
-        List<String> capitalizedWords = capitalizeWords(words);
-        return joinWords(capitalizedWords);
-    }
-
-    private List<String> capitalizeWords(String[] words) {
-        return Arrays.stream(words)
-                .filter(word -> !word.isEmpty())
-                .map(this::capitalizeWord)
-                .collect(Collectors.toList());
-    }
-
-    private String joinWords(List<String> words) {
-        return String.join(" ", words);
-    }
-
-    private String capitalizeWord(String word) {
-        return word.substring(0, 1).toUpperCase()
-                + word.substring(1).toLowerCase();
+        return name.trim().replaceAll("\\s+", " ");
     }
 
     @Override
@@ -100,7 +60,7 @@ public class Name {
         }
 
         Name otherName = (Name) other;
-        return fullName.equals(otherName.fullName);
+        return fullName.equalsIgnoreCase(otherName.fullName);
     }
 
     @Override

--- a/src/test/java/tuteez/model/person/NameTest.java
+++ b/src/test/java/tuteez/model/person/NameTest.java
@@ -32,13 +32,6 @@ public class NameTest {
     }
 
     @Test
-    public void constructor_titlecaseHandling() {
-        assertEquals("John Smith", new Name("john smith").toString());
-        assertEquals("John Smith", new Name("JOHN SMITH").toString());
-        assertEquals("John Smith", new Name("joHN SMiTh").toString());
-    }
-
-    @Test
     public void isValidName() {
         // null name
         assertThrows(NullPointerException.class, () -> Name.isValidName(null));
@@ -63,6 +56,9 @@ public class NameTest {
 
         // same values -> returns true
         assertTrue(name.equals(new Name("Valid Name")));
+
+        // same values, different capitalisation -> returns true
+        assertTrue(name.equals(new Name("VaLiD nAME")));
 
         // same object -> returns true
         assertTrue(name.equals(name));


### PR DESCRIPTION
Fixes #209

## What is this PR for?
It may be better to allow users the flexibility of deciding the title-case of `name` (while still checking for duplicates case-insensitively)

## What does this PR do?
This PR removes the auto-titlecasing of `name` to allow users more flexibility in this regard. It still checks for duplicates case-insensitively, so `add` and `edit` work as normal.