### PR TITLE
Refactor DeleteLessonCommand to sort lessons before deleting

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -215,7 +215,7 @@ Format: `deletelesson INDEX li/LESSON_INDEX [li/LESSON_INDEX]…​`
 
 * short form: `dellsn INDEX li/LESSON_INDEX [li/LESSON_INDEX]…​`
 * Deletes lesson(s) from the student at the specified `INDEX`. The index refers to the index number shown in the displayed student list. The index **must be a positive integer** 1, 2, 3, …​
-* Lessons are indexed based on the order they were added to the student, starting from 1.
+* Lessons are indexed starting from 1 and sorted in ascending order based on their day and time.
 * If the `LESSON_INDEX` is not valid, an error will be shown.
 
 Examples:

--- a/src/main/java/tuteez/logic/commands/AddLessonCommand.java
+++ b/src/main/java/tuteez/logic/commands/AddLessonCommand.java
@@ -141,7 +141,7 @@ public class AddLessonCommand extends LessonCommand {
     private String formatLessonList(List<Lesson> lessons) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < lessons.size(); i++) {
-            sb.append(i + 1).append(". ").append(lessons.get(i).toString()).append("\n");
+            sb.append("• ").append(lessons.get(i).toString()).append("\n");
         }
         return sb.toString();
     }

--- a/src/main/java/tuteez/logic/commands/DeleteLessonCommand.java
+++ b/src/main/java/tuteez/logic/commands/DeleteLessonCommand.java
@@ -42,7 +42,9 @@ public class DeleteLessonCommand extends LessonCommand {
 
         Person personToUpdate = getPersonFromModel(model);
 
-        List<Lesson> currentLessons = new ArrayList<>(personToUpdate.getLessons());
+        List<Lesson> currentLessons = new ArrayList<>(personToUpdate.getLessons().stream()
+                .sorted(new Lesson.LessonComparator())
+                .toList());
         List<Lesson> lessonsToDelete = new ArrayList<>();
         List<Index> invalidIndices = new ArrayList<>();
 
@@ -82,7 +84,7 @@ public class DeleteLessonCommand extends LessonCommand {
     private String formatLessonList(List<Lesson> lessons) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < lessons.size(); i++) {
-            sb.append(i + 1).append(". ").append(lessons.get(i).toString());
+            sb.append("• ").append(lessons.get(i).toString());
             if (i < lessons.size() - 1) {
                 sb.append("\n");
             }

--- a/src/test/java/tuteez/logic/commands/AddLessonCommandTest.java
+++ b/src/test/java/tuteez/logic/commands/AddLessonCommandTest.java
@@ -251,7 +251,7 @@ public class AddLessonCommandTest {
     private String formatLessonList(List<Lesson> lessons) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < lessons.size(); i++) {
-            sb.append(i + 1).append(". ").append(lessons.get(i).toString()).append("\n");
+            sb.append("• ").append(lessons.get(i).toString()).append("\n");
         }
         return sb.toString();
     }

--- a/src/test/java/tuteez/logic/commands/DeleteLessonCommandTest.java
+++ b/src/test/java/tuteez/logic/commands/DeleteLessonCommandTest.java
@@ -177,8 +177,7 @@ public class DeleteLessonCommandTest {
     private String formatLessonList(List<Lesson> lessons) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < lessons.size(); i++) {
-            sb.append(i + 1).append(". ").append(lessons.get(i).toString());
-            // Only add newline if not the last lesson
+            sb.append("• ").append(lessons.get(i).toString());
             if (i < lessons.size() - 1) {
                 sb.append("\n");
             }


### PR DESCRIPTION
Fixes #232 

## What is this PR for?
Previously deleting lessons would delete according to the order the user added the lessons for that particular student. Now, to streamline it with the UI displayed lessons in the displayed person card, we have to sort the lessons first before deleting it, so that it would be a more accurate implementation as that is what the UI currently follows.

## What does this PR do?
Implement sorting of lessons before deleting. 
Update necessary tests.
Update output messages.
Change user guide to accurately reflect new implementation.