### PR TITLE
Make index error more specific

### DIFF
--- a/src/main/java/tuteez/logic/Messages.java
+++ b/src/main/java/tuteez/logic/Messages.java
@@ -20,7 +20,8 @@ public class Messages {
     public static final String MESSAGE_MISSING_PERSON_INDEX =
             "Student index is required but missing. Please provide the index of the student as displayed in the list.";
     public static final String MESSAGE_INVALID_PERSON_INDEX_FORMAT =
-            "Student index must be a single, positive number (eg, '1', '2', '3').";
+            "Student index must be a single, positive number (eg, '1', '2', '3'). "
+                    + "However, it is currently detected as: %1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The student index provided is invalid";
     public static final String MESSAGE_MISSING_PERSON_NAME =
             "Student's name is required but missing. Please provide the name of the student using n/.";

--- a/src/main/java/tuteez/logic/Messages.java
+++ b/src/main/java/tuteez/logic/Messages.java
@@ -38,8 +38,8 @@ public class Messages {
     public static final String MESSAGE_MISSING_REMARK_INDEX_PREFIX = "The remark index prefix 'ri/' is missing";
     public static final String MESSAGE_MISSING_REMARK_INDEX = "Remark index is required for deletion but missing. "
             + "Please specify which remark to delete (e.g., 'deleteremark 1 ri/1').";
-    public static final String MESSAGE_INVALID_REMARK_INDEX_FORMAT =
-            "Remark index must be a single, positive number (eg, '1', '2', '3').";
+    public static final String MESSAGE_INVALID_REMARK_INDEX_FORMAT = "Remark index must be a single, positive number "
+        + "(eg, '1', '2', '3'). However, it is currently detected as: %1$s";
     public static final String MESSAGE_INVALID_REMARK_INDEX = "The remark index provided is out of bounds.";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_NAME =
                 "No student named %1$s was found, please try again!";

--- a/src/main/java/tuteez/logic/commands/AddCommand.java
+++ b/src/main/java/tuteez/logic/commands/AddCommand.java
@@ -37,7 +37,7 @@ public class AddCommand extends Command {
             + "Optional Parameters:"
             + " [" + PREFIX_EMAIL + "EMAIL]"
             + " [" + PREFIX_ADDRESS + "ADDRESS]"
-            + " [" + PREFIX_TELEGRAM + "TELEGRAM USERNAME]"
+            + " [" + PREFIX_TELEGRAM + "TELEGRAM_USERNAME]"
             + " [" + PREFIX_TAG + "TAG]..."
             + " [" + PREFIX_LESSON + "LESSON]...\n"
             + "Example: " + COMMAND_WORD + " "

--- a/src/main/java/tuteez/logic/commands/EditCommand.java
+++ b/src/main/java/tuteez/logic/commands/EditCommand.java
@@ -60,7 +60,8 @@ public class EditCommand extends Command {
             + "Note: Lessons can be added or removed via the 'addlesson' or 'deletelesson' commands respectively.";
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited student: %1$s";
-    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_NOT_EDITED = "At least one of the following fields to edit must be provided:"
+            + " n/NAME p/PHONE e/EMAIL a/ADDRESS tg/TELEGRAM_USERNAME t/TAG";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;

--- a/src/main/java/tuteez/logic/parser/AddLessonCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/AddLessonCommandParser.java
@@ -63,7 +63,7 @@ public class AddLessonCommandParser implements Parser<LessonCommand> {
             index = ParserUtil.parseIndex(preamble);
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    MESSAGE_INVALID_PERSON_INDEX_FORMAT));
+                    String.format(MESSAGE_INVALID_PERSON_INDEX_FORMAT, preamble)));
         }
         return index;
     }

--- a/src/main/java/tuteez/logic/parser/AddRemarkCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/AddRemarkCommandParser.java
@@ -61,7 +61,7 @@ public class AddRemarkCommandParser implements Parser<AddRemarkCommand> {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    MESSAGE_INVALID_PERSON_INDEX_FORMAT));
+                    String.format(MESSAGE_INVALID_PERSON_INDEX_FORMAT, argMultimap.getPreamble())));
         }
         return index;
     }

--- a/src/main/java/tuteez/logic/parser/AddRemarkCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/AddRemarkCommandParser.java
@@ -58,10 +58,10 @@ public class AddRemarkCommandParser implements Parser<AddRemarkCommand> {
         Index index;
 
         try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            index = ParserUtil.parseIndex(preamble);
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    String.format(MESSAGE_INVALID_PERSON_INDEX_FORMAT, argMultimap.getPreamble())));
+                    String.format(MESSAGE_INVALID_PERSON_INDEX_FORMAT, preamble)));
         }
         return index;
     }

--- a/src/main/java/tuteez/logic/parser/DeleteLessonCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/DeleteLessonCommandParser.java
@@ -67,7 +67,7 @@ public class DeleteLessonCommandParser implements Parser<LessonCommand> {
             index = ParserUtil.parseIndex(preamble);
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    MESSAGE_INVALID_PERSON_INDEX_FORMAT));
+                    String.format(MESSAGE_INVALID_PERSON_INDEX_FORMAT, preamble)));
         }
         return index;
     }

--- a/src/main/java/tuteez/logic/parser/DeleteRemarkCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/DeleteRemarkCommandParser.java
@@ -59,10 +59,10 @@ public class DeleteRemarkCommandParser implements Parser<DeleteRemarkCommand> {
         Index index;
 
         try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            index = ParserUtil.parseIndex(preamble);
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    MESSAGE_INVALID_PERSON_INDEX_FORMAT));
+                    String.format(MESSAGE_INVALID_PERSON_INDEX_FORMAT, preamble)));
         }
         return index;
     }

--- a/src/main/java/tuteez/logic/parser/DeleteRemarkCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/DeleteRemarkCommandParser.java
@@ -84,7 +84,7 @@ public class DeleteRemarkCommandParser implements Parser<DeleteRemarkCommand> {
             index = ParserUtil.parseIndex(remarkIndexStr);
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    MESSAGE_INVALID_REMARK_INDEX_FORMAT));
+                    String.format(MESSAGE_INVALID_REMARK_INDEX_FORMAT, remarkIndexStr)));
         }
         return new DeleteRemarkCommand(personIndex, index);
     }

--- a/src/test/java/tuteez/logic/parser/AddLessonCommandParserTest.java
+++ b/src/test/java/tuteez/logic/parser/AddLessonCommandParserTest.java
@@ -59,8 +59,8 @@ public class AddLessonCommandParserTest {
     @Test
     public void parse_invalidPersonIndex_throwsParseException() {
         String userInput = "0 " + PREFIX_LESSON + VALID_LESSON_MONDAY;
-        assertParseFailure(parser, userInput,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_INVALID_PERSON_INDEX_FORMAT));
+        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                String.format(MESSAGE_INVALID_PERSON_INDEX_FORMAT, "0")));
     }
 
     @Test

--- a/src/test/java/tuteez/logic/parser/AddRemarkCommandParserTest.java
+++ b/src/test/java/tuteez/logic/parser/AddRemarkCommandParserTest.java
@@ -53,7 +53,7 @@ public class AddRemarkCommandParserTest {
     public void parse_invalidPersonIndex_throwsParseException() {
         // Invalid index for add remark
         assertParseFailure(parser, "0 " + PREFIX_REMARK + " Some remark",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_INVALID_PERSON_INDEX_FORMAT));
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, String.format(MESSAGE_INVALID_PERSON_INDEX_FORMAT, "0")));
     }
 
     @Test

--- a/src/test/java/tuteez/logic/parser/DeleteLessonCommandParserTest.java
+++ b/src/test/java/tuteez/logic/parser/DeleteLessonCommandParserTest.java
@@ -3,6 +3,7 @@ package tuteez.logic.parser;
 import static tuteez.logic.Messages.MESSAGE_DUPLICATE_LESSON_INDEX;
 import static tuteez.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static tuteez.logic.Messages.MESSAGE_INVALID_LESSON_INDEX_FORMAT;
+import static tuteez.logic.Messages.MESSAGE_INVALID_PERSON_INDEX_FORMAT;
 import static tuteez.logic.Messages.MESSAGE_MISSING_LESSON_INDEX;
 import static tuteez.logic.Messages.MESSAGE_MISSING_LESSON_INDEX_FIELD_PREFIX;
 import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON_INDEX;
@@ -52,6 +53,12 @@ public class DeleteLessonCommandParserTest {
     public void parse_whitespaceOnlyAfterCommandWord_throwsParseException() {
         assertParseFailure(parser, " ",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteLessonCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidPersonIndex_throwsParseException() {
+        assertParseFailure(parser, "0 " + PREFIX_LESSON_INDEX + "1",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, String.format(MESSAGE_INVALID_PERSON_INDEX_FORMAT, "0")));
     }
 
     @Test

--- a/src/test/java/tuteez/logic/parser/DeleteRemarkCommandParserTest.java
+++ b/src/test/java/tuteez/logic/parser/DeleteRemarkCommandParserTest.java
@@ -68,9 +68,10 @@ public class DeleteRemarkCommandParserTest {
     @Test
     public void parse_invalidRemarkIndex_throwsParseException() {
         assertParseFailure(parser, String.format("1 %s 0", PREFIX_REMARK_INDEX),
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_INVALID_REMARK_INDEX_FORMAT));
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, String.format(MESSAGE_INVALID_REMARK_INDEX_FORMAT, "0")));
 
         assertParseFailure(parser, String.format("1 %s -1", PREFIX_REMARK_INDEX),
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_INVALID_REMARK_INDEX_FORMAT));
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        String.format(MESSAGE_INVALID_REMARK_INDEX_FORMAT, "-1")));
     }
 }

--- a/src/test/java/tuteez/logic/parser/DeleteRemarkCommandParserTest.java
+++ b/src/test/java/tuteez/logic/parser/DeleteRemarkCommandParserTest.java
@@ -1,6 +1,7 @@
 package tuteez.logic.parser;
 
 import static tuteez.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static tuteez.logic.Messages.MESSAGE_INVALID_PERSON_INDEX_FORMAT;
 import static tuteez.logic.Messages.MESSAGE_INVALID_REMARK_INDEX_FORMAT;
 import static tuteez.logic.Messages.MESSAGE_MISSING_REMARK_INDEX;
 import static tuteez.logic.Messages.MESSAGE_MISSING_REMARK_INDEX_PREFIX;
@@ -38,6 +39,12 @@ public class DeleteRemarkCommandParserTest {
 
         assertParseFailure(parser, "1 a/ Some remark",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_REMARK_INDEX_PREFIX));
+    }
+
+    @Test
+    public void parse_invalidPersonIndex_throwsParseException() {
+        assertParseFailure(parser, "0 " + PREFIX_REMARK_INDEX + "1",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, String.format(MESSAGE_INVALID_PERSON_INDEX_FORMAT, "0")));
     }
 
     @Test

--- a/src/test/java/tuteez/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/tuteez/logic/parser/EditCommandParserTest.java
@@ -1,6 +1,8 @@
 package tuteez.logic.parser;
 
 import static tuteez.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static tuteez.logic.Messages.MESSAGE_INVALID_PERSON_INDEX_FORMAT;
+import static tuteez.logic.Messages.MESSAGE_MISSING_PERSON_INDEX;
 import static tuteez.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static tuteez.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static tuteez.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
@@ -66,32 +68,35 @@ public class EditCommandParserTest {
     @Test
     public void parse_missingParts_failure() {
         // no index specified
-        assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, VALID_NAME_AMY, EditCommand.MESSAGE_NOT_EDITED);
 
         // no field specified
         assertParseFailure(parser, "1", EditCommand.MESSAGE_NOT_EDITED);
 
         // no index and no field specified
-        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, " ", MESSAGE_INVALID_FORMAT);
 
         // No index but valid command otherwise
-        assertParseFailure(parser, " t/math", Messages.MESSAGE_MISSING_PERSON_INDEX);
+        assertParseFailure(parser, " t/math", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                MESSAGE_MISSING_PERSON_INDEX));
 
     }
 
     @Test
     public void parse_invalidPreamble_failure() {
         // negative index
-        assertParseFailure(parser, "-5" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "-5" + NAME_DESC_AMY, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                String.format(MESSAGE_INVALID_PERSON_INDEX_FORMAT, "-5")));
 
         // zero index
-        assertParseFailure(parser, "0" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "0" + NAME_DESC_AMY, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                String.format(MESSAGE_INVALID_PERSON_INDEX_FORMAT, "0")));
 
         // invalid arguments being parsed as preamble
-        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 some random string", EditCommand.MESSAGE_NOT_EDITED);
 
         // invalid prefix being parsed as preamble
-        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 i/ string", EditCommand.MESSAGE_NOT_EDITED);
     }
 
     @Test


### PR DESCRIPTION
Fixes #230 
- Adds message that indicates what is detected as the student index to improve clarity

## Note
Previously, the `edit` parser did not have error detection for this. I changed it's implementation so that it acts more similarly to `addremark` and `addlesson`