### PR TITLE
Eliminate code duplication in parser classes

### DIFF
--- a/src/main/java/tuteez/logic/parser/AddLessonCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/AddLessonCommandParser.java
@@ -6,6 +6,8 @@ import static tuteez.logic.Messages.MESSAGE_INVALID_PERSON_INDEX_FORMAT;
 import static tuteez.logic.Messages.MESSAGE_MISSING_LESSON_FIELD_PREFIX;
 import static tuteez.logic.Messages.MESSAGE_MISSING_PERSON_INDEX;
 import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON;
+import static tuteez.logic.parser.ParserUtil.validateNonEmptyArgs;
+import static tuteez.logic.parser.ParserUtil.validatePrefixExists;
 
 import java.util.List;
 
@@ -28,26 +30,12 @@ public class AddLessonCommandParser implements Parser<LessonCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_LESSON);
 
-        validateBasicCommandFormat(args);
-        validatePrefixExists(argMultimap);
+        validateNonEmptyArgs(args, AddLessonCommand.MESSAGE_USAGE);
+        validatePrefixExists(argMultimap, PREFIX_LESSON, MESSAGE_MISSING_LESSON_FIELD_PREFIX);
 
         Index personIndex = parsePersonIndex(argMultimap);
 
         return createAddLessonCommand(personIndex, argMultimap);
-    }
-
-    private void validateBasicCommandFormat(String args) throws ParseException {
-        if (args.trim().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    AddLessonCommand.MESSAGE_USAGE));
-        }
-    }
-
-    private void validatePrefixExists(ArgumentMultimap argMultimap) throws ParseException {
-        if (!argMultimap.getValue(PREFIX_LESSON).isPresent()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    MESSAGE_MISSING_LESSON_FIELD_PREFIX));
-        }
     }
 
     private Index parsePersonIndex(ArgumentMultimap argMultimap) throws ParseException {

--- a/src/main/java/tuteez/logic/parser/AddLessonCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/AddLessonCommandParser.java
@@ -1,13 +1,9 @@
 package tuteez.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static tuteez.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static tuteez.logic.Messages.MESSAGE_INVALID_PERSON_INDEX_FORMAT;
 import static tuteez.logic.Messages.MESSAGE_MISSING_LESSON_FIELD_PREFIX;
-import static tuteez.logic.Messages.MESSAGE_MISSING_PERSON_INDEX;
 import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON;
-import static tuteez.logic.parser.ParserUtil.validateNonEmptyArgs;
-import static tuteez.logic.parser.ParserUtil.validatePrefixExists;
+import static tuteez.logic.parser.ParserUtil.*;
 
 import java.util.List;
 
@@ -36,24 +32,6 @@ public class AddLessonCommandParser implements Parser<LessonCommand> {
         Index personIndex = parsePersonIndex(argMultimap);
 
         return createAddLessonCommand(personIndex, argMultimap);
-    }
-
-    private Index parsePersonIndex(ArgumentMultimap argMultimap) throws ParseException {
-        String preamble = argMultimap.getPreamble().trim();
-
-        if (preamble.isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    MESSAGE_MISSING_PERSON_INDEX));
-        }
-
-        Index index;
-        try {
-            index = ParserUtil.parseIndex(preamble);
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    String.format(MESSAGE_INVALID_PERSON_INDEX_FORMAT, preamble)));
-        }
-        return index;
     }
 
     private AddLessonCommand createAddLessonCommand(Index personIndex, ArgumentMultimap argMultimap)

--- a/src/main/java/tuteez/logic/parser/AddRemarkCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/AddRemarkCommandParser.java
@@ -6,6 +6,8 @@ import static tuteez.logic.Messages.MESSAGE_INVALID_PERSON_INDEX_FORMAT;
 import static tuteez.logic.Messages.MESSAGE_MISSING_PERSON_INDEX;
 import static tuteez.logic.Messages.MESSAGE_MISSING_REMARK_PREFIX;
 import static tuteez.logic.parser.CliSyntax.PREFIX_REMARK;
+import static tuteez.logic.parser.ParserUtil.validateNonEmptyArgs;
+import static tuteez.logic.parser.ParserUtil.validatePrefixExists;
 
 import tuteez.commons.core.index.Index;
 import tuteez.logic.commands.AddRemarkCommand;
@@ -26,26 +28,14 @@ public class AddRemarkCommandParser implements Parser<AddRemarkCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_REMARK);
 
-        validateBasicCommandFormat(args);
-        validatePrefixExists(argMultimap);
+        validateNonEmptyArgs(args, AddRemarkCommand.MESSAGE_USAGE);
+        validatePrefixExists(argMultimap, PREFIX_REMARK, MESSAGE_MISSING_REMARK_PREFIX);
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_REMARK);
 
         Index personIndex = parsePersonIndex(argMultimap);
 
         return createAddRemarkCommand(personIndex, argMultimap);
-    }
-
-    private void validateBasicCommandFormat(String args) throws ParseException {
-        if (args.trim().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddRemarkCommand.MESSAGE_USAGE));
-        }
-    }
-
-    private void validatePrefixExists(ArgumentMultimap argMultimap) throws ParseException {
-        if (!argMultimap.getValue(PREFIX_REMARK).isPresent()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_REMARK_PREFIX));
-        }
     }
 
     private Index parsePersonIndex(ArgumentMultimap argMultimap) throws ParseException {

--- a/src/main/java/tuteez/logic/parser/AddRemarkCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/AddRemarkCommandParser.java
@@ -1,13 +1,9 @@
 package tuteez.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static tuteez.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static tuteez.logic.Messages.MESSAGE_INVALID_PERSON_INDEX_FORMAT;
-import static tuteez.logic.Messages.MESSAGE_MISSING_PERSON_INDEX;
 import static tuteez.logic.Messages.MESSAGE_MISSING_REMARK_PREFIX;
 import static tuteez.logic.parser.CliSyntax.PREFIX_REMARK;
-import static tuteez.logic.parser.ParserUtil.validateNonEmptyArgs;
-import static tuteez.logic.parser.ParserUtil.validatePrefixExists;
+import static tuteez.logic.parser.ParserUtil.*;
 
 import tuteez.commons.core.index.Index;
 import tuteez.logic.commands.AddRemarkCommand;
@@ -36,24 +32,6 @@ public class AddRemarkCommandParser implements Parser<AddRemarkCommand> {
         Index personIndex = parsePersonIndex(argMultimap);
 
         return createAddRemarkCommand(personIndex, argMultimap);
-    }
-
-    private Index parsePersonIndex(ArgumentMultimap argMultimap) throws ParseException {
-        String preamble = argMultimap.getPreamble().trim();
-
-        if (preamble.isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_PERSON_INDEX));
-        }
-
-        Index index;
-
-        try {
-            index = ParserUtil.parseIndex(preamble);
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    String.format(MESSAGE_INVALID_PERSON_INDEX_FORMAT, preamble)));
-        }
-        return index;
     }
 
     private AddRemarkCommand createAddRemarkCommand(Index personIndex, ArgumentMultimap argMultimap)

--- a/src/main/java/tuteez/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/DeleteCommandParser.java
@@ -2,9 +2,9 @@ package tuteez.logic.parser;
 
 import static tuteez.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static tuteez.logic.Messages.MESSAGE_INVALID_PERSON_INDEX_FORMAT;
+import static tuteez.logic.parser.ParserUtil.validateNonEmptyArgs;
 
 import tuteez.commons.core.index.Index;
-import tuteez.logic.commands.AddLessonCommand;
 import tuteez.logic.commands.DeleteCommand;
 import tuteez.logic.parser.exceptions.ParseException;
 import tuteez.model.person.Name;
@@ -20,20 +20,13 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
-        validateBasicCommandFormat(args);
+        validateNonEmptyArgs(args, DeleteCommand.MESSAGE_USAGE);
         if (args.trim().matches("-?\\d+")) {
             Index index = parsePersonIndex(args);
             return new DeleteCommand(index);
         } else {
             Name name = ParserUtil.parseName(args);
             return new DeleteCommand(name);
-        }
-    }
-
-    private void validateBasicCommandFormat(String args) throws ParseException {
-        if (args.trim().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    AddLessonCommand.MESSAGE_USAGE));
         }
     }
 

--- a/src/main/java/tuteez/logic/parser/DeleteLessonCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/DeleteLessonCommandParser.java
@@ -10,6 +10,8 @@ import static tuteez.logic.Messages.MESSAGE_MISSING_LESSON_INDEX_FIELD_PREFIX;
 import static tuteez.logic.Messages.MESSAGE_MISSING_PERSON_INDEX;
 import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON_INDEX;
 import static tuteez.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
+import static tuteez.logic.parser.ParserUtil.validateNonEmptyArgs;
+import static tuteez.logic.parser.ParserUtil.validatePrefixExists;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,26 +34,12 @@ public class DeleteLessonCommandParser implements Parser<LessonCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_LESSON_INDEX);
 
-        validateBasicCommandFormat(args);
-        validatePrefixExists(argMultimap);
+        validateNonEmptyArgs(args, DeleteLessonCommand.MESSAGE_USAGE);
+        validatePrefixExists(argMultimap, PREFIX_LESSON_INDEX, MESSAGE_MISSING_LESSON_INDEX_FIELD_PREFIX);
 
         Index personIndex = parsePersonIndex(argMultimap);
 
         return createDeleteLessonCommand(personIndex, argMultimap);
-    }
-
-    private void validateBasicCommandFormat(String args) throws ParseException {
-        if (args.trim().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    DeleteLessonCommand.MESSAGE_USAGE));
-        }
-    }
-
-    private void validatePrefixExists(ArgumentMultimap argMultimap) throws ParseException {
-        if (!argMultimap.getValue(PREFIX_LESSON_INDEX).isPresent()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    MESSAGE_MISSING_LESSON_INDEX_FIELD_PREFIX));
-        }
     }
 
     private Index parsePersonIndex(ArgumentMultimap argMultimap) throws ParseException {

--- a/src/main/java/tuteez/logic/parser/DeleteLessonCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/DeleteLessonCommandParser.java
@@ -9,9 +9,7 @@ import static tuteez.logic.Messages.MESSAGE_MISSING_LESSON_INDEX;
 import static tuteez.logic.Messages.MESSAGE_MISSING_LESSON_INDEX_FIELD_PREFIX;
 import static tuteez.logic.Messages.MESSAGE_MISSING_PERSON_INDEX;
 import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON_INDEX;
-import static tuteez.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
-import static tuteez.logic.parser.ParserUtil.validateNonEmptyArgs;
-import static tuteez.logic.parser.ParserUtil.validatePrefixExists;
+import static tuteez.logic.parser.ParserUtil.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,24 +38,6 @@ public class DeleteLessonCommandParser implements Parser<LessonCommand> {
         Index personIndex = parsePersonIndex(argMultimap);
 
         return createDeleteLessonCommand(personIndex, argMultimap);
-    }
-
-    private Index parsePersonIndex(ArgumentMultimap argMultimap) throws ParseException {
-        String preamble = argMultimap.getPreamble().trim();
-
-        if (preamble.isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    MESSAGE_MISSING_PERSON_INDEX));
-        }
-
-        Index index;
-        try {
-            index = ParserUtil.parseIndex(preamble);
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    String.format(MESSAGE_INVALID_PERSON_INDEX_FORMAT, preamble)));
-        }
-        return index;
     }
 
     private DeleteLessonCommand createDeleteLessonCommand(Index personIndex, ArgumentMultimap argMultimap)

--- a/src/main/java/tuteez/logic/parser/DeleteRemarkCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/DeleteRemarkCommandParser.java
@@ -8,8 +8,7 @@ import static tuteez.logic.Messages.MESSAGE_MISSING_PERSON_INDEX;
 import static tuteez.logic.Messages.MESSAGE_MISSING_REMARK_INDEX;
 import static tuteez.logic.Messages.MESSAGE_MISSING_REMARK_INDEX_PREFIX;
 import static tuteez.logic.parser.CliSyntax.PREFIX_REMARK_INDEX;
-import static tuteez.logic.parser.ParserUtil.validateNonEmptyArgs;
-import static tuteez.logic.parser.ParserUtil.validatePrefixExists;
+import static tuteez.logic.parser.ParserUtil.*;
 
 import tuteez.commons.core.index.Index;
 import tuteez.logic.commands.DeleteRemarkCommand;
@@ -36,24 +35,6 @@ public class DeleteRemarkCommandParser implements Parser<DeleteRemarkCommand> {
         Index personIndex = parsePersonIndex(argMultimap);
 
         return createDeleteRemarkCommand(personIndex, argMultimap);
-    }
-
-    private Index parsePersonIndex(ArgumentMultimap argMultimap) throws ParseException {
-        String preamble = argMultimap.getPreamble().trim();
-
-        if (preamble.isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_PERSON_INDEX));
-        }
-
-        Index index;
-
-        try {
-            index = ParserUtil.parseIndex(preamble);
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    String.format(MESSAGE_INVALID_PERSON_INDEX_FORMAT, preamble)));
-        }
-        return index;
     }
 
     private DeleteRemarkCommand createDeleteRemarkCommand(Index personIndex, ArgumentMultimap argMultimap)

--- a/src/main/java/tuteez/logic/parser/DeleteRemarkCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/DeleteRemarkCommandParser.java
@@ -8,6 +8,8 @@ import static tuteez.logic.Messages.MESSAGE_MISSING_PERSON_INDEX;
 import static tuteez.logic.Messages.MESSAGE_MISSING_REMARK_INDEX;
 import static tuteez.logic.Messages.MESSAGE_MISSING_REMARK_INDEX_PREFIX;
 import static tuteez.logic.parser.CliSyntax.PREFIX_REMARK_INDEX;
+import static tuteez.logic.parser.ParserUtil.validateNonEmptyArgs;
+import static tuteez.logic.parser.ParserUtil.validatePrefixExists;
 
 import tuteez.commons.core.index.Index;
 import tuteez.logic.commands.DeleteRemarkCommand;
@@ -25,28 +27,15 @@ public class DeleteRemarkCommandParser implements Parser<DeleteRemarkCommand> {
      */
     public DeleteRemarkCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        validateBasicCommandFormat(args);
+        validateNonEmptyArgs(args, DeleteRemarkCommand.MESSAGE_USAGE);
 
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_REMARK_INDEX);
-        validatePrefixExists(argMultimap);
+        validatePrefixExists(argMultimap, PREFIX_REMARK_INDEX, MESSAGE_MISSING_REMARK_INDEX_PREFIX);
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_REMARK_INDEX);
 
         Index personIndex = parsePersonIndex(argMultimap);
 
         return createDeleteRemarkCommand(personIndex, argMultimap);
-    }
-
-    private void validateBasicCommandFormat(String args) throws ParseException {
-        if (args.trim().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteRemarkCommand.MESSAGE_USAGE));
-        }
-    }
-
-    private void validatePrefixExists(ArgumentMultimap argMultimap) throws ParseException {
-        if (!argMultimap.getValue(PREFIX_REMARK_INDEX).isPresent()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    MESSAGE_MISSING_REMARK_INDEX_PREFIX));
-        }
     }
 
     private Index parsePersonIndex(ArgumentMultimap argMultimap) throws ParseException {

--- a/src/main/java/tuteez/logic/parser/EditCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/EditCommandParser.java
@@ -1,15 +1,13 @@
 package tuteez.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static tuteez.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static tuteez.logic.Messages.MESSAGE_INVALID_PERSON_INDEX_FORMAT;
-import static tuteez.logic.Messages.MESSAGE_MISSING_PERSON_INDEX;
 import static tuteez.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static tuteez.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static tuteez.logic.parser.CliSyntax.PREFIX_NAME;
 import static tuteez.logic.parser.CliSyntax.PREFIX_PHONE;
 import static tuteez.logic.parser.CliSyntax.PREFIX_TAG;
 import static tuteez.logic.parser.CliSyntax.PREFIX_TELEGRAM;
+import static tuteez.logic.parser.ParserUtil.parsePersonIndex;
 import static tuteez.logic.parser.ParserUtil.validateNonEmptyArgs;
 
 import java.util.Collection;
@@ -116,23 +114,5 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
         return Optional.of(ParserUtil.parseTags(tagSet));
-    }
-
-    private Index parsePersonIndex(ArgumentMultimap argMultimap) throws ParseException {
-        String preamble = argMultimap.getPreamble().trim();
-
-        if (preamble.isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_PERSON_INDEX));
-        }
-
-        Index index;
-
-        try {
-            index = ParserUtil.parseIndex(preamble);
-        } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    String.format(MESSAGE_INVALID_PERSON_INDEX_FORMAT, preamble)));
-        }
-        return index;
     }
 }

--- a/src/main/java/tuteez/logic/parser/EditCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/EditCommandParser.java
@@ -10,6 +10,7 @@ import static tuteez.logic.parser.CliSyntax.PREFIX_NAME;
 import static tuteez.logic.parser.CliSyntax.PREFIX_PHONE;
 import static tuteez.logic.parser.CliSyntax.PREFIX_TAG;
 import static tuteez.logic.parser.CliSyntax.PREFIX_TELEGRAM;
+import static tuteez.logic.parser.ParserUtil.validateNonEmptyArgs;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -37,7 +38,7 @@ public class EditCommandParser implements Parser<EditCommand> {
      */
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        validateBasicCommandFormat(args);
+        validateNonEmptyArgs(args, EditCommand.MESSAGE_USAGE);
 
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
@@ -133,11 +134,5 @@ public class EditCommandParser implements Parser<EditCommand> {
                     String.format(MESSAGE_INVALID_PERSON_INDEX_FORMAT, preamble)));
         }
         return index;
-    }
-
-    private void validateBasicCommandFormat(String args) throws ParseException {
-        if (args.trim().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
-        }
     }
 }

--- a/src/main/java/tuteez/logic/parser/FindCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/FindCommandParser.java
@@ -1,5 +1,6 @@
 package tuteez.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static tuteez.logic.Messages.MESSAGE_EMPTY_KEYWORD;
 import static tuteez.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static tuteez.logic.Messages.MESSAGE_MISSING_PREFIX_FOR_FIND;
@@ -8,6 +9,7 @@ import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON_DAY;
 import static tuteez.logic.parser.CliSyntax.PREFIX_LESSON_TIME;
 import static tuteez.logic.parser.CliSyntax.PREFIX_NAME;
 import static tuteez.logic.parser.CliSyntax.PREFIX_TAG;
+import static tuteez.logic.parser.ParserUtil.validateNonEmptyArgs;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -37,11 +39,8 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-        }
+        requireNonNull(args);
+        validateNonEmptyArgs(args, FindCommand.MESSAGE_USAGE);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_ADDRESS,
                 PREFIX_TAG, PREFIX_LESSON_DAY, PREFIX_LESSON_TIME);
 

--- a/src/main/java/tuteez/logic/parser/ParserUtil.java
+++ b/src/main/java/tuteez/logic/parser/ParserUtil.java
@@ -1,7 +1,7 @@
 package tuteez.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static tuteez.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static tuteez.logic.Messages.*;
 
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
@@ -283,6 +283,32 @@ public class ParserUtil {
         if (!argMultimap.getValue(prefix).isPresent()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, errorMessage));
         }
+    }
+
+    /**
+     * Parses the person index from the provided {@code ArgumentMultimap}.
+     * Validates that the preamble contains a valid index and throws a {@code ParseException} if invalid.
+     *
+     * @param argMultimap The argument multimap to retrieve the preamble from.
+     * @return The parsed {@code Index}.
+     * @throws ParseException if the preamble is empty or contains an invalid index.
+     */
+     public static Index parsePersonIndex(ArgumentMultimap argMultimap) throws ParseException {
+        String preamble = argMultimap.getPreamble().trim();
+
+        if (preamble.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MISSING_PERSON_INDEX));
+        }
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(preamble);
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    String.format(MESSAGE_INVALID_PERSON_INDEX_FORMAT, preamble)));
+        }
+        return index;
     }
 
 }

--- a/src/main/java/tuteez/logic/parser/ParserUtil.java
+++ b/src/main/java/tuteez/logic/parser/ParserUtil.java
@@ -1,6 +1,7 @@
 package tuteez.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static tuteez.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
@@ -253,4 +254,35 @@ public class ParserUtil {
         }
         return new Remark(trimmedRemark);
     }
+
+    /**
+     * Validates that the provided {@code String args} is not empty or only whitespace.
+     * If invalid, throws a {@code ParseException} with the provided {@code errorMessage}.
+     *
+     * @param args The args to validate.
+     * @param errorMessage The error message to use in the exception if validation fails.
+     * @throws ParseException if {@code args} is empty or contains only whitespace.
+     */
+    public static void validateNonEmptyArgs(String args, String errorMessage) throws ParseException {
+        if (args.trim().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, errorMessage));
+        }
+    }
+
+    /**
+     * Validates that the specified {@code Prefix} exists in the given {@code ArgumentMultimap}.
+     * If the prefix is missing, throws a {@code ParseException} with the provided {@code errorMessage}.
+     *
+     * @param argMultimap The map of arguments to check.
+     * @param prefix The prefix to validate.
+     * @param errorMessage The error message to use in the exception if validation fails.
+     * @throws ParseException if the specified {@code prefix} is not present in {@code argMultimap}.
+     */
+    public static void validatePrefixExists(ArgumentMultimap argMultimap, Prefix prefix, String errorMessage)
+            throws ParseException {
+        if (!argMultimap.getValue(prefix).isPresent()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, errorMessage));
+        }
+    }
+
 }


### PR DESCRIPTION
Fixes #316

## What is this PR for?
Currently, multiple parser classes handle certain inputs for error detection using similar logic, but each class has its own individual method. To adhere to DRY principles, we should abstract this common functionality into a utility class.

## What does this PR do?
The common methods `validateNonEmptyArgs()` `validatePrefixExists()` `parsePersonIndex()` are abstracted into the `ParserUtil.java` class and removed from their respective classes.

## Notes
In `DeleteCommandParser.java` class, there is a `parsePersonIndex()` method. But it's implementation is significantly different that of the other parser classes, hence the class still uses its own private method for this.