### PR TITLE
Correct delete error message for incorrect format

### DIFF
--- a/src/main/java/tuteez/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/tuteez/logic/parser/DeleteCommandParser.java
@@ -21,9 +21,12 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      */
     public DeleteCommand parse(String args) throws ParseException {
         validateNonEmptyArgs(args, DeleteCommand.MESSAGE_USAGE);
-        if (args.trim().matches("-?\\d+")) {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.matches("-?\\d+")) {
             Index index = parsePersonIndex(args);
             return new DeleteCommand(index);
+        } else if (trimmedArgs.matches("^\\d+\\s+.*")) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         } else {
             Name name = ParserUtil.parseName(args);
             return new DeleteCommand(name);

--- a/src/test/java/tuteez/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/tuteez/logic/parser/DeleteCommandParserTest.java
@@ -33,8 +33,19 @@ public class DeleteCommandParserTest {
     }
 
     @Test
-    public void parse_invalidArgs_throwsParseException() {
+    public void parse_invalidArgsWithIndex_throwsParseException() {
         assertParseFailure(parser, "-1", (String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 String.format(MESSAGE_INVALID_PERSON_INDEX_FORMAT, "-1"))));
+    }
+
+    @Test
+    public void parse_invalidArgsWithName_throwsParseException() {
+        assertParseFailure(parser, "alice*", Name.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_invalidFormat_throwsParseException() {
+        assertParseFailure(parser, "0 li/", (String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteCommand.MESSAGE_USAGE)));
     }
 }


### PR DESCRIPTION
Fixes #327

## What is this PR for?
`delete 0 li/` throws the error for invalid names. This error message does not match the input. Instead, we should change it to the more general error message for delete

## What does this PR do?
`delete NUMBER ANYTHING` -> throws general delete message usage
eg:
- `delete 0 li/`
- `delete 1 john doe`
- `delete 1 2`

## Note
For `delete john doe li/`, the application will search for a student named `john doe li/` and will not throw an error